### PR TITLE
feat: add create_dataset tool with tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 MCP_HOST=127.0.0.1
 MCP_PORT="8000"
 DATAGOUV_ENV="prod"
+# Required for write operations (create dataset, etc.)
+# Get your key from: https://www.data.gouv.fr/fr/admin/me
+# DATAGOUV_API_KEY=""

--- a/helpers/env_config.py
+++ b/helpers/env_config.py
@@ -44,3 +44,14 @@ def get_base_url(api_name: str) -> str:
             f"Valid values are: {', '.join(config.keys())}"
         )
     return config[api_name]
+
+
+def get_api_key() -> str | None:
+    """
+    Return the data.gouv.fr API key from the DATAGOUV_API_KEY environment variable.
+
+    Returns None if the variable is unset or empty.
+    The key is required for write operations (POST/PUT/PATCH/DELETE).
+    It can be obtained from the user's profile settings on data.gouv.fr.
+    """
+    return os.getenv("DATAGOUV_API_KEY", "").strip() or None

--- a/tests/test_create_dataset.py
+++ b/tests/test_create_dataset.py
@@ -1,0 +1,399 @@
+"""Tests for the create_dataset API client function and tool safety logic."""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from helpers import datagouv_api_client, env_config
+
+
+class TestGetApiKey:
+    """Tests for the get_api_key helper."""
+
+    def test_get_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("DATAGOUV_API_KEY", "test-key-123")
+        assert env_config.get_api_key() == "test-key-123"
+
+    def test_get_api_key_strips_whitespace(self, monkeypatch):
+        monkeypatch.setenv("DATAGOUV_API_KEY", "  test-key-123  ")
+        assert env_config.get_api_key() == "test-key-123"
+
+    def test_get_api_key_returns_none_when_empty(self, monkeypatch):
+        monkeypatch.setenv("DATAGOUV_API_KEY", "")
+        assert env_config.get_api_key() is None
+
+    def test_get_api_key_returns_none_when_whitespace_only(self, monkeypatch):
+        monkeypatch.setenv("DATAGOUV_API_KEY", "   ")
+        assert env_config.get_api_key() is None
+
+    def test_get_api_key_returns_none_when_unset(self, monkeypatch):
+        monkeypatch.delenv("DATAGOUV_API_KEY", raising=False)
+        assert env_config.get_api_key() is None
+
+
+@pytest.mark.asyncio
+class TestCreateDatasetClient:
+    """Tests for the create_dataset API client function."""
+
+    async def test_create_dataset_builds_correct_payload(self):
+        """Test that create_dataset sends the right payload to the API."""
+        mock_response = httpx.Response(
+            status_code=201,
+            json={
+                "id": "abc123",
+                "title": "Test Dataset",
+                "slug": "test-dataset",
+                "private": True,
+                "frequency": "monthly",
+                "license": "fr-lo",
+            },
+            request=httpx.Request("POST", "https://www.data.gouv.fr/api/1/datasets/"),
+        )
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.aclose = AsyncMock()
+
+        result = await datagouv_api_client.create_dataset(
+            title="Test Dataset",
+            description="A test description",
+            api_key="fake-key",
+            frequency="monthly",
+            organization="org-123",
+            license_id="fr-lo",
+            tags=["test", "example"],
+            private=True,
+            session=mock_client,
+        )
+
+        # Verify the API was called
+        mock_client.post.assert_called_once()
+        call_kwargs = mock_client.post.call_args
+
+        # Check URL
+        assert "/1/datasets/" in call_kwargs.args[0]
+
+        # Check headers contain API key
+        assert call_kwargs.kwargs["headers"]["X-API-KEY"] == "fake-key"
+
+        # Check payload
+        payload = call_kwargs.kwargs["json"]
+        assert payload["title"] == "Test Dataset"
+        assert payload["description"] == "A test description"
+        assert payload["frequency"] == "monthly"
+        assert payload["organization"] == "org-123"
+        assert payload["license"] == "fr-lo"
+        assert payload["tags"] == ["test", "example"]
+        assert payload["private"] is True
+
+        # Check result
+        assert result["id"] == "abc123"
+        assert result["title"] == "Test Dataset"
+
+    async def test_create_dataset_without_organization(self):
+        """Test that organization is omitted from payload when not provided."""
+        mock_response = httpx.Response(
+            status_code=201,
+            json={"id": "abc123", "title": "Personal Dataset"},
+            request=httpx.Request("POST", "https://www.data.gouv.fr/api/1/datasets/"),
+        )
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.aclose = AsyncMock()
+
+        await datagouv_api_client.create_dataset(
+            title="Personal Dataset",
+            description="Description",
+            api_key="fake-key",
+            session=mock_client,
+        )
+
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert "organization" not in payload
+
+    async def test_create_dataset_without_tags(self):
+        """Test that tags are omitted from payload when not provided."""
+        mock_response = httpx.Response(
+            status_code=201,
+            json={"id": "abc123", "title": "No Tags Dataset"},
+            request=httpx.Request("POST", "https://www.data.gouv.fr/api/1/datasets/"),
+        )
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.aclose = AsyncMock()
+
+        await datagouv_api_client.create_dataset(
+            title="No Tags Dataset",
+            description="Description",
+            api_key="fake-key",
+            session=mock_client,
+        )
+
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert "tags" not in payload
+
+    async def test_create_dataset_defaults(self):
+        """Test default values for optional parameters."""
+        mock_response = httpx.Response(
+            status_code=201,
+            json={"id": "abc123"},
+            request=httpx.Request("POST", "https://www.data.gouv.fr/api/1/datasets/"),
+        )
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.aclose = AsyncMock()
+
+        await datagouv_api_client.create_dataset(
+            title="Defaults Test",
+            description="Description",
+            api_key="fake-key",
+            session=mock_client,
+        )
+
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["frequency"] == "unknown"
+        assert payload["license"] == "fr-lo"
+        assert payload["private"] is True
+
+    async def test_create_dataset_http_error_propagates(self):
+        """Test that HTTP errors from the API are raised."""
+        mock_response = httpx.Response(
+            status_code=401,
+            json={"message": "Invalid API key"},
+            request=httpx.Request("POST", "https://example.com"),
+        )
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.aclose = AsyncMock()
+
+        # raise_for_status() should be called inside _post_json
+        # We need the mock to actually raise
+        mock_response.raise_for_status = lambda: (_ for _ in ()).throw(
+            httpx.HTTPStatusError(
+                "401 Unauthorized",
+                request=mock_response.request,
+                response=mock_response,
+            )
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await datagouv_api_client.create_dataset(
+                title="Should Fail",
+                description="Description",
+                api_key="bad-key",
+                session=mock_client,
+            )
+
+
+class TestCreateDatasetToolSafety:
+    """Tests for the create_dataset tool-level safety checks.
+
+    These test the validation logic in the tool layer (tools/create_dataset.py)
+    by importing and calling the tool registration and then the inner function.
+    """
+
+    @pytest.fixture
+    def tool_func(self):
+        """Get the create_dataset tool function by registering it on a mock MCP."""
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        from tools.create_dataset import register_create_dataset_tool
+
+        register_create_dataset_tool(mcp)
+
+        # The tool is registered; find it by name
+        tool = mcp._tool_manager._tools.get("create_dataset")
+        assert tool is not None, "create_dataset tool was not registered"
+        return tool.fn
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_returns_error(self, tool_func, monkeypatch):
+        monkeypatch.delenv("DATAGOUV_API_KEY", raising=False)
+        result = await tool_func(title="Test", description="Test description")
+        assert "Error" in result
+        assert "No API key configured" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_frequency_returns_error(self, tool_func, monkeypatch):
+        monkeypatch.setenv("DATAGOUV_API_KEY", "fake-key")
+        result = await tool_func(
+            title="Test",
+            description="Test description",
+            frequency="every-5-minutes",
+        )
+        assert "Error" in result
+        assert "Invalid frequency" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_title_returns_error(self, tool_func, monkeypatch):
+        monkeypatch.setenv("DATAGOUV_API_KEY", "fake-key")
+        result = await tool_func(title="", description="Some description")
+        assert "Error" in result
+        assert "title is required" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_description_returns_error(self, tool_func, monkeypatch):
+        monkeypatch.setenv("DATAGOUV_API_KEY", "fake-key")
+        result = await tool_func(title="Valid Title", description="")
+        assert "Error" in result
+        assert "description is required" in result
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_title_returns_error(self, tool_func, monkeypatch):
+        monkeypatch.setenv("DATAGOUV_API_KEY", "fake-key")
+        result = await tool_func(title="   ", description="Some description")
+        assert "Error" in result
+        assert "title is required" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_creation_returns_info(self, tool_func, monkeypatch):
+        monkeypatch.setenv("DATAGOUV_API_KEY", "fake-key")
+        monkeypatch.setenv("DATAGOUV_ENV", "demo")
+
+        mock_result = {
+            "id": "abc123",
+            "title": "My New Dataset",
+            "slug": "my-new-dataset",
+            "private": True,
+            "license": "fr-lo",
+            "frequency": "monthly",
+        }
+
+        with patch.object(
+            datagouv_api_client, "create_dataset", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = mock_result
+
+            result = await tool_func(
+                title="My New Dataset",
+                description="A description",
+                frequency="monthly",
+            )
+
+            assert "created successfully" in result
+            assert "abc123" in result
+            assert "my-new-dataset" in result
+            assert "PRIVATE (draft)" in result
+            assert "demo.data.gouv.fr" in result
+
+    @pytest.mark.asyncio
+    async def test_prod_env_label_in_response(self, tool_func, monkeypatch):
+        monkeypatch.setenv("DATAGOUV_API_KEY", "fake-key")
+        monkeypatch.setenv("DATAGOUV_ENV", "prod")
+
+        mock_result = {
+            "id": "abc123",
+            "title": "Prod Dataset",
+            "slug": "prod-dataset",
+            "private": True,
+            "license": "fr-lo",
+            "frequency": "unknown",
+        }
+
+        with patch.object(
+            datagouv_api_client, "create_dataset", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = mock_result
+
+            result = await tool_func(
+                title="Prod Dataset",
+                description="A description",
+            )
+
+            assert "PRODUCTION" in result
+
+    @pytest.mark.asyncio
+    async def test_public_dataset_status_in_response(self, tool_func, monkeypatch):
+        monkeypatch.setenv("DATAGOUV_API_KEY", "fake-key")
+        monkeypatch.setenv("DATAGOUV_ENV", "demo")
+
+        mock_result = {
+            "id": "abc123",
+            "title": "Public Dataset",
+            "slug": "public-dataset",
+            "private": False,
+            "license": "fr-lo",
+            "frequency": "unknown",
+        }
+
+        with patch.object(
+            datagouv_api_client, "create_dataset", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = mock_result
+
+            result = await tool_func(
+                title="Public Dataset",
+                description="A description",
+                private=False,
+            )
+
+            assert "PUBLIC" in result
+
+    @pytest.mark.asyncio
+    async def test_auth_error_returns_helpful_message(self, tool_func, monkeypatch):
+        monkeypatch.setenv("DATAGOUV_API_KEY", "bad-key")
+        monkeypatch.setenv("DATAGOUV_ENV", "demo")
+
+        mock_request = httpx.Request(
+            "POST", "https://demo.data.gouv.fr/api/1/datasets/"
+        )
+        mock_response = httpx.Response(
+            status_code=401,
+            json={"message": "Invalid API key"},
+            request=mock_request,
+        )
+        http_error = httpx.HTTPStatusError(
+            "401 Unauthorized", request=mock_request, response=mock_response
+        )
+
+        with patch.object(
+            datagouv_api_client, "create_dataset", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.side_effect = http_error
+
+            result = await tool_func(
+                title="Should Fail",
+                description="A description",
+            )
+
+            assert "Authentication failed" in result
+            assert "401" in result
+
+    @pytest.mark.asyncio
+    async def test_permission_error_returns_helpful_message(
+        self, tool_func, monkeypatch
+    ):
+        monkeypatch.setenv("DATAGOUV_API_KEY", "valid-key")
+        monkeypatch.setenv("DATAGOUV_ENV", "demo")
+
+        mock_request = httpx.Request(
+            "POST", "https://demo.data.gouv.fr/api/1/datasets/"
+        )
+        mock_response = httpx.Response(
+            status_code=403,
+            json={"message": "You do not have permission"},
+            request=mock_request,
+        )
+        http_error = httpx.HTTPStatusError(
+            "403 Forbidden", request=mock_request, response=mock_response
+        )
+
+        with patch.object(
+            datagouv_api_client, "create_dataset", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.side_effect = http_error
+
+            result = await tool_func(
+                title="Should Fail",
+                description="A description",
+                organization="some-org-id",
+            )
+
+            assert "Permission denied" in result
+            assert "403" in result

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,5 +1,6 @@
 from mcp.server.fastmcp import FastMCP
 
+from tools.create_dataset import register_create_dataset_tool
 from tools.download_and_parse_resource import (
     register_download_and_parse_resource_tool,
 )
@@ -18,6 +19,7 @@ from tools.search_datasets import register_search_datasets_tool
 
 def register_tools(mcp: FastMCP) -> None:
     """Register all MCP tools with the provided FastMCP instance."""
+    # Read-only tools
     register_search_datasets_tool(mcp)
     register_search_dataservices_tool(mcp)
     register_get_dataservice_info_tool(mcp)
@@ -28,3 +30,5 @@ def register_tools(mcp: FastMCP) -> None:
     register_get_resource_info_tool(mcp)
     register_download_and_parse_resource_tool(mcp)
     register_get_metrics_tool(mcp)
+    # Write tools
+    register_create_dataset_tool(mcp)

--- a/tools/create_dataset.py
+++ b/tools/create_dataset.py
@@ -1,0 +1,189 @@
+import logging
+import os
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+from helpers import datagouv_api_client, env_config
+
+logger = logging.getLogger("datagouv_mcp")
+
+VALID_FREQUENCIES = {
+    "unknown",
+    "punctual",
+    "continuous",
+    "hourly",
+    "fourTimesADay",
+    "threeTimesADay",
+    "semidaily",
+    "daily",
+    "fourTimesAWeek",
+    "threeTimesAWeek",
+    "semiweekly",
+    "weekly",
+    "biweekly",
+    "threeTimesAMonth",
+    "semimonthly",
+    "monthly",
+    "bimonthly",
+    "quarterly",
+    "threeTimesAYear",
+    "semiannual",
+    "annual",
+    "biennial",
+    "triennial",
+    "quinquennial",
+    "irregular",
+}
+
+
+def register_create_dataset_tool(mcp: FastMCP) -> None:
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=True,
+            idempotentHint=False,
+            openWorldHint=True,
+        )
+    )
+    async def create_dataset(
+        title: str,
+        description: str,
+        frequency: str = "unknown",
+        organization: str | None = None,
+        license: str = "fr-lo",
+        tags: list[str] | None = None,
+        private: bool = True,
+    ) -> str:
+        """
+        Create a new dataset on data.gouv.fr.
+
+        This is a WRITE operation that creates a real dataset on data.gouv.fr.
+        By default, datasets are created as private DRAFTS (not visible publicly).
+        Set private=False only when you are ready to publish.
+
+        Requires a DATAGOUV_API_KEY environment variable to be set.
+
+        Args:
+            title: Dataset title (required).
+            description: Dataset description, supports markdown (required).
+            frequency: Update frequency (default: "unknown"). Valid values:
+                unknown, punctual, continuous, hourly, daily, weekly, monthly,
+                quarterly, semiannual, annual, irregular, and more.
+            organization: Organization ID to publish under (optional).
+                If omitted, published under the user's personal account.
+            license: License identifier (default: "fr-lo" = Licence Ouverte).
+            tags: List of tags (optional).
+            private: If True (default), create as draft (not publicly visible).
+        """
+        # Check API key
+        api_key = env_config.get_api_key()
+        if not api_key:
+            return (
+                "Error: No API key configured.\n"
+                "Set the DATAGOUV_API_KEY environment variable to publish datasets.\n"
+                "You can get your API key from your data.gouv.fr profile settings:\n"
+                "https://www.data.gouv.fr/fr/admin/me"
+            )
+
+        # Validate frequency
+        if frequency not in VALID_FREQUENCIES:
+            return (
+                f"Error: Invalid frequency '{frequency}'.\n"
+                f"Valid values are: {', '.join(sorted(VALID_FREQUENCIES))}"
+            )
+
+        # Validate required fields
+        if not title or not title.strip():
+            return "Error: title is required and cannot be empty."
+        if not description or not description.strip():
+            return "Error: description is required and cannot be empty."
+
+        # Determine environment for user context
+        current_env: str = os.getenv("DATAGOUV_ENV", "prod").strip().lower()
+        env_label = (
+            "demo.data.gouv.fr"
+            if current_env == "demo"
+            else "www.data.gouv.fr (PRODUCTION)"
+        )
+
+        try:
+            result = await datagouv_api_client.create_dataset(
+                title=title.strip(),
+                description=description.strip(),
+                api_key=api_key,
+                frequency=frequency,
+                organization=organization,
+                license_id=license,
+                tags=tags,
+                private=private,
+            )
+
+            dataset_id = result.get("id", "unknown")
+            slug = result.get("slug", dataset_id)
+            site_url = f"{env_config.get_base_url('site')}datasets/{slug}/"
+            status = "PRIVATE (draft)" if result.get("private", True) else "PUBLIC"
+
+            content_parts = [
+                f"Dataset created successfully on {env_label}:",
+                "",
+                f"  Title: {result.get('title', title)}",
+                f"  ID: {dataset_id}",
+                f"  Slug: {slug}",
+                f"  URL: {site_url}",
+                f"  Status: {status}",
+                f"  License: {result.get('license', license)}",
+                f"  Frequency: {result.get('frequency', frequency)}",
+            ]
+
+            if result.get("organization"):
+                org = result["organization"]
+                if isinstance(org, dict):
+                    content_parts.append(f"  Organization: {org.get('name', '')}")
+
+            content_parts.append("")
+            content_parts.append("Next steps:")
+            content_parts.append(
+                "  - Add resources (files) to this dataset using add_resource"
+            )
+            if result.get("private", True):
+                content_parts.append(
+                    "  - When ready, set private=False to make it publicly visible"
+                )
+
+            logger.info(
+                "Dataset created: id=%s title='%s' env=%s private=%s",
+                dataset_id,
+                title,
+                current_env,
+                private,
+            )
+
+            return "\n".join(content_parts)
+
+        except httpx.HTTPStatusError as e:
+            status_code = e.response.status_code
+            try:
+                error_body = e.response.json()
+                error_msg = error_body.get("message", str(e))
+            except Exception:  # noqa: BLE001
+                error_msg = str(e)
+
+            if status_code == 401:
+                return (
+                    "Error: Authentication failed (HTTP 401).\n"
+                    "Your API key may be invalid or expired.\n"
+                    "Check your DATAGOUV_API_KEY environment variable."
+                )
+            if status_code == 403:
+                return (
+                    f"Error: Permission denied (HTTP 403).\n"
+                    f"You may not have permission to publish "
+                    f"{'for this organization' if organization else 'with this account'}.\n"
+                    f"Details: {error_msg}"
+                )
+            return f"Error: HTTP {status_code} - {error_msg}"
+        except Exception as e:  # noqa: BLE001
+            logger.exception("Unexpected error in create_dataset tool")
+            return f"Error creating dataset: {str(e)}"

--- a/tools/download_and_parse_resource.py
+++ b/tools/download_and_parse_resource.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from helpers import datagouv_api_client
 
@@ -14,7 +15,7 @@ logger = logging.getLogger("datagouv_mcp")
 
 
 def register_download_and_parse_resource_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def download_and_parse_resource(
         resource_id: str,
         max_rows: int = 20,

--- a/tools/get_dataservice_info.py
+++ b/tools/get_dataservice_info.py
@@ -2,12 +2,13 @@ from typing import Any
 
 import httpx
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from helpers import datagouv_api_client, env_config
 
 
 def register_get_dataservice_info_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_dataservice_info(dataservice_id: str) -> str:
         """
         Get detailed metadata about a specific dataservice (external third-party API).

--- a/tools/get_dataservice_openapi_spec.py
+++ b/tools/get_dataservice_openapi_spec.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import httpx
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from helpers import datagouv_api_client
 
@@ -84,7 +85,7 @@ def _summarize_spec(spec: dict[str, Any]) -> str:
 
 
 def register_get_dataservice_openapi_spec_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_dataservice_openapi_spec(dataservice_id: str) -> str:
         """
         Fetch and summarize the OpenAPI/Swagger spec for a dataservice (external third-party API).

--- a/tools/get_dataset_info.py
+++ b/tools/get_dataset_info.py
@@ -1,11 +1,12 @@
 import httpx
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from helpers import datagouv_api_client, env_config
 
 
 def register_get_dataset_info_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_dataset_info(dataset_id: str) -> str:
         """
         Get detailed metadata about a specific dataset.

--- a/tools/get_metrics.py
+++ b/tools/get_metrics.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from helpers import datagouv_api_client, metrics_api_client
 
@@ -9,7 +10,7 @@ logger = logging.getLogger("datagouv_mcp")
 
 
 def register_get_metrics_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_metrics(
         dataset_id: str | None = None,
         resource_id: str | None = None,

--- a/tools/get_resource_info.py
+++ b/tools/get_resource_info.py
@@ -1,11 +1,12 @@
 import httpx
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from helpers import crawler_api_client, datagouv_api_client, env_config
 
 
 def register_get_resource_info_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def get_resource_info(resource_id: str) -> str:
         """
         Get detailed information about a specific resource (file).

--- a/tools/list_dataset_resources.py
+++ b/tools/list_dataset_resources.py
@@ -2,6 +2,7 @@ import logging
 
 import httpx
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from helpers import datagouv_api_client
 
@@ -9,7 +10,7 @@ logger = logging.getLogger("datagouv_mcp")
 
 
 def register_list_dataset_resources_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def list_dataset_resources(dataset_id: str) -> str:
         """
         List all resources (files) in a dataset with their metadata.

--- a/tools/query_resource_data.py
+++ b/tools/query_resource_data.py
@@ -2,6 +2,7 @@ import logging
 
 import httpx
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from helpers import datagouv_api_client, tabular_api_client
 
@@ -9,7 +10,7 @@ logger = logging.getLogger("datagouv_mcp")
 
 
 def register_query_resource_data_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def query_resource_data(
         question: str,
         resource_id: str,

--- a/tools/search_dataservices.py
+++ b/tools/search_dataservices.py
@@ -1,6 +1,7 @@
 import logging
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from helpers import datagouv_api_client
 from tools.search_datasets import clean_search_query
@@ -9,7 +10,7 @@ logger = logging.getLogger("datagouv_mcp")
 
 
 def register_search_dataservices_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def search_dataservices(
         query: str, page: int = 1, page_size: int = 20
     ) -> str:

--- a/tools/search_datasets.py
+++ b/tools/search_datasets.py
@@ -1,6 +1,7 @@
 import logging
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from helpers import datagouv_api_client
 
@@ -57,7 +58,7 @@ def clean_search_query(query: str) -> str:
 
 
 def register_search_datasets_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     async def search_datasets(query: str, page: int = 1, page_size: int = 20) -> str:
         """
         Search for datasets on data.gouv.fr by keywords.


### PR DESCRIPTION
## Summary

- Add `create_dataset` MCP tool to publish datasets on data.gouv.fr via the API
- Add MCP `ToolAnnotations` to all tools (read-only hints on existing tools, destructive/write hints on the new one)
- Add `DATAGOUV_API_KEY` support for authenticated write operations

## Details

### New tool: `create_dataset`

Creates a new dataset on data.gouv.fr. Requires `DATAGOUV_API_KEY` env var.

**Safety measures:**
- `private=True` by default — datasets are created as **drafts**, not publicly visible
- MCP `ToolAnnotations`: `destructiveHint=True`, `idempotentHint=False`, `openWorldHint=True` — MCP clients (Cursor, Claude Desktop, etc.) will prompt the user for confirmation before each call
- Fail-fast API key check with helpful error message if missing
- Input validation: frequency enum, non-empty title/description
- Environment label in response (`demo.data.gouv.fr` vs `www.data.gouv.fr (PRODUCTION)`)
- Structured error messages for HTTP 401 (auth) and 403 (permissions)

**Parameters:** `title`, `description`, `frequency`, `organization`, `license`, `tags`, `private`

### New files

| File | Description |
|---|---|
| `tools/create_dataset.py` | MCP tool definition with annotations and safety checks |
| `tests/test_create_dataset.py` | 20 tests covering API client, auth helper, and tool-level safety |

### Modified files

| File | Change |
|---|---|
| `helpers/env_config.py` | Added `get_api_key()` to read `DATAGOUV_API_KEY` from env |
| `helpers/datagouv_api_client.py` | Added `_post_json()` helper and `create_dataset()` client function |
| `tools/__init__.py` | Registered `create_dataset` tool, organized read/write sections |
| `.env.example` | Added commented `DATAGOUV_API_KEY` with documentation link |
| All 10 existing tool files | Added `ToolAnnotations(readOnlyHint=True)` to `@mcp.tool()` |

### Safety measures

- **Drafts by default**: datasets are created with `private=true`, meaning they are invisible to the public until explicitly published
- **MCP tool annotations**: the `create_dataset` tool is annotated with `destructiveHint=true` and `idempotentHint=false`, so MCP-compliant clients (Cursor, Claude Desktop, VS Code, etc.) will ask for user confirmation before each call
- **Input validation**: frequency, title, and description are validated before sending to the API
- **Error messages**: authentication (401) and permission (403) errors return actionable guidance

### Deferred (next iterations)

- Rate limiter (anti-loop protection at server level)
- Duplicate title checker
- `add_resource`, `update_dataset`, `create_reuse`, `create_dataservice` tools

## Test plan

- [x] 20 new unit tests pass (`tests/test_create_dataset.py`)
- [x] Full test suite passes (77 tests)
- [x] Ruff linter: 0 errors
- [ ] Manual test: create a private dataset on `demo.data.gouv.fr` with a valid API key
- [ ] Manual test: verify MCP client shows confirmation prompt before calling `create_dataset`