### PR TITLE
feat: add ZIP archive support to download_and_parse_resource

### DIFF
--- a/tests/test_parse_zip.py
+++ b/tests/test_parse_zip.py
@@ -5,7 +5,7 @@ import zipfile
 
 import pytest
 
-from tools.download_and_parse_resource import _parse_zip
+from tools.download_and_parse_resource import _detect_file_format, _parse_zip
 
 
 def _make_zip(files: dict[str, str]) -> bytes:
@@ -94,3 +94,17 @@ class TestParseZip:
         assert filename == "subdir/data.csv"
         assert len(rows) == 1
         assert rows[0]["a"] == "1"
+
+
+class TestDetectZipByContentType:
+    def test_detects_zip_from_application_zip(self):
+        assert _detect_file_format("resource", "application/zip") == "zip"
+
+    def test_detects_zip_from_x_zip_compressed(self):
+        assert _detect_file_format("resource", "application/x-zip-compressed") == "zip"
+
+    def test_does_not_confuse_gzip_with_zip(self):
+        assert _detect_file_format("resource", "application/gzip") == "gzip"
+
+    def test_extension_takes_priority_over_content_type(self):
+        assert _detect_file_format("data.zip", "application/octet-stream") == "zip"

--- a/tools/download_and_parse_resource.py
+++ b/tools/download_and_parse_resource.py
@@ -250,6 +250,8 @@ def _detect_file_format(filename: str, content_type: str | None) -> str:
             return "xml"
         elif "excel" in content_type or "spreadsheet" in content_type:
             return "xlsx"
+        elif "zip" in content_type and "gzip" not in content_type:
+            return "zip"
         elif "gzip" in content_type:
             return "gzip"
 


### PR DESCRIPTION
## Summary

Closes #16

- `download_and_parse_resource` now handles ZIP archives by extracting and parsing the first supported file (CSV, JSON, JSONL, NDJSON) inside the archive
- Many datasets on data.gouv.fr are distributed as ZIP files (e.g. INSEE "Nombre de naissances annuelles par commune"), which previously returned "Format not supported for parsing"
- Skips macOS `__MACOSX` metadata directories and selects files deterministically (alphabetical order)

## Changes

- **`tools/download_and_parse_resource.py`**: Added `_parse_zip()` function and ZIP handling branch in the format dispatcher. Updated docstring and supported formats list.
- **`tests/test_parse_zip.py`**: 8 unit tests covering CSV/JSON/JSONL extraction, alphabetical selection, `__MACOSX` filtering, nested paths, empty archives, and unsupported-only archives.

## Test plan

- [x] All 65 tests pass (57 existing + 8 new)
- [x] Ruff lint and format checks pass
- [ ] Manual test: try `download_and_parse_resource` on a ZIP resource (e.g. INSEE resource `bb88ea88-c4bd-4e92-bfc9-2d89e40d660f`)