### PR TITLE
fix: Remove 'transport' field for the Gemini CLI configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Add the following to your `~/.gemini/settings.json` file:
 {
   "mcpServers": {
     "datagouv": {
-      "transport": "http",
       "httpUrl": "https://mcp.data.gouv.fr/mcp"
     }
   }


### PR DESCRIPTION
Gemini CLI uses either the `httpUrl` field for Streamable HTTP, or `url` for Server-Sent-Events. The `transport` field for the MCP configuration is not recognized by Gemini CLI.