### PR TITLE
fix: update docker-compose healthcheck to /health

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - MATOMO_AUTH=${MATOMO_AUTH}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "python", "-c", "import os, urllib.request; port = os.getenv('MCP_PORT', '8000'); urllib.request.urlopen(f'http://localhost:{port}/mcp')"]
+      test: ["CMD", "python", "-c", "import os, urllib.request; port = os.getenv('MCP_PORT', '8000'); urllib.request.urlopen(f'http://localhost:{port}/health')"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
Updates the Docker Compose healthcheck probe to target `GET /health` instead of `/mcp`.

## Why
`/health` is the dedicated lightweight health endpoint, while `/mcp` is the JSON-RPC transport endpoint.

## Changes
- In `docker-compose.yml`, healthcheck URL changed from:
  - `http://localhost:${MCP_PORT}/mcp`
  to
  - `http://localhost:${MCP_PORT}/health`

## Validation
- `docker compose config`
- `uv run pytest -q tests/test_health_endpoint.py`
