### PR TITLE
fix: return explicit errors for invalid filter/sort options

### DIFF
--- a/tools/query_resource_data.py
+++ b/tools/query_resource_data.py
@@ -31,6 +31,28 @@ def register_query_resource_data_tool(mcp: FastMCP) -> None:
         may be more efficient than paginating through many pages.
         """
         try:
+            filter_operator = filter_operator.lower()
+            sort_direction = sort_direction.lower()
+
+            operator_map = {
+                "exact": "exact",
+                "contains": "contains",
+                "less": "less",
+                "greater": "greater",
+                "strictly_less": "strictly_less",
+                "strictly_greater": "strictly_greater",
+            }
+            if filter_column and filter_value is not None:
+                if filter_operator not in operator_map:
+                    supported = ", ".join(sorted(operator_map.keys()))
+                    return (
+                        "Error: invalid filter_operator. "
+                        f"Supported values: {supported}."
+                    )
+
+            if sort_column and sort_direction not in {"asc", "desc"}:
+                return "Error: invalid sort_direction. Supported values: asc, desc."
+
             # Get resource metadata to display context
             try:
                 resource_metadata = await datagouv_api_client.get_resource_metadata(
@@ -84,23 +106,13 @@ def register_query_resource_data_tool(mcp: FastMCP) -> None:
 
             # Add filter if provided
             if filter_column and filter_value is not None:
-                # Map simple operator names to Tabular API operators
-                operator_map = {
-                    "exact": "exact",
-                    "contains": "contains",
-                    "less": "less",
-                    "greater": "greater",
-                    "strictly_less": "strictly_less",
-                    "strictly_greater": "strictly_greater",
-                }
-                operator = operator_map.get(filter_operator, "exact")
+                operator = operator_map[filter_operator]
                 param_key = f"{filter_column}__{operator}"
                 api_params[param_key] = filter_value
 
             # Add sort if provided
             if sort_column:
-                sort_dir = "desc" if sort_direction.lower() == "desc" else "asc"
-                api_params[f"{sort_column}__sort"] = sort_dir
+                api_params[f"{sort_column}__sort"] = sort_direction
 
             logger.info(
                 f"Querying Tabular API for resource: {resource_title} "


### PR DESCRIPTION
## Summary
Adds explicit validation for `filter_operator` and `sort_direction` in `query_resource_data`.

## Why
Current behavior silently falls back to defaults when unsupported values are passed. Returning explicit errors is safer and makes tool behavior easier to debug.

## Changes
- Normalize `filter_operator` and `sort_direction` to lowercase.
- Validate `filter_operator` when filtering is requested.
- Validate `sort_direction` when sorting is requested.
- Return clear error messages for invalid values instead of silently defaulting.

## Validation
- `uv run ruff check tools/query_resource_data.py`
- `uv run ty check tools/query_resource_data.py`
- `uv run pytest -q tests/test_tabular_api.py`
