### PR TITLE
fix: add OAuth 2.0 discovery endpoint for Claude Code

### DIFF
--- a/main.py
+++ b/main.py
@@ -77,6 +77,24 @@ def with_monitoring(
                 await send({"type": "http.response.body", "body": body})
                 return
 
+            # OAuth 2.0 discovery endpoint (for Claude Code HTTP transport)
+            if path == "/.well-known/oauth-authorization-server":
+                oauth_response = {
+                    "authorization_endpoint": "urn:ietf:wg:oauth:2.0:oob",
+                    "token_endpoint": "urn:ietf:wg:oauth:2.0:oob",
+                    "response_types_supported": ["token"],
+                    "grant_types_supported": ["client_credentials"],
+                    "token_endpoint_auth_methods_supported": ["none"]
+                }
+                body = json.dumps(oauth_response).encode("utf-8")
+                oauth_headers = [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode("utf-8")),
+                ]
+                await send({"type": "http.response.start", "status": 200, "headers": oauth_headers})
+                await send({"type": "http.response.body", "body": body})
+                return
+
             # Matomo Tracking for /mcp requests
             # Convert ASGI headers list to a dictionary for the helper
             headers_dict: dict[str, str] = {


### PR DESCRIPTION
## Summary

Fixes #26 - Add OAuth 2.0 Authorization Server Metadata endpoint.

## Problem

Claude Code HTTP transport performs OAuth discovery by hitting:
```
GET /.well-known/oauth-authorization-server
```

The production server returns 404, causing Claude Code to fail.

## Solution

Added `/.well-known/oauth-authorization-server` endpoint returning valid OAuth 2.0 Authorization Server Metadata (RFC 8414).

References:
- RFC 8414: OAuth 2.0 Authorization Server Metadata
- MCP Specification: Transport Security

Fixes #26