### PR TITLE
docs: add Mistral (web) connector instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ Use the hosted endpoint `https://mcp.data.gouv.fr/mcp` (recommended). If you sel
 
 The MCP server configuration depends on your client. Use the appropriate configuration format for your client:
 
+### Mistral (web)
+
+*Available on all plans, including free.*
+
+1. **Go to Connectors**: Open Mistral in your browser, then go to `Intelligence` > `Connectors`.
+2. **Add a custom connector**: Click `Add connector` > `Custom MCP Connector`, give it a name (for example `DataGouv`), and set the server URL to `https://mcp.data.gouv.fr/mcp`.
+3. **No authentication**: Leave authentication disabled.
+4. **Create**: Click **Create**.
+
 ### ChatGPT
 
 *Available for paid plans only (Plus, Pro, Team, and Enterprise).*


### PR DESCRIPTION
## Summary
Add Mistral (web) connection instructions to the README before the existing ChatGPT section.

## Changes
- add a new Mistral (web) subsection under chatbot connection instructions
- document navigation path: Intelligence > Connectors
- document connector setup path: Add connector > Custom MCP Connector
- set server URL to https://mcp.data.gouv.fr/mcp
- mention no authentication and creation step

## Testing
- documentation-only change
- verified section order and wording in README.md