### PR TITLE
fix(csv): add encoding fallback for non-UTF-8 CSV files

### DIFF
--- a/tools/download_and_parse_resource.py
+++ b/tools/download_and_parse_resource.py
@@ -252,11 +252,20 @@ def _detect_file_format(filename: str, content_type: str | None) -> str:
 
 
 def _parse_csv(content: bytes, is_gzipped: bool = False) -> list[dict[str, Any]]:
-    """Parse CSV content with automatic delimiter detection."""
+    """Parse CSV content with automatic delimiter and encoding detection."""
     if is_gzipped:
         content = gzip.decompress(content)
 
-    text = content.decode("utf-8-sig")  # Handle BOM
+    # Try UTF-8 first (with BOM handling), then fall back to other encodings
+    text = None
+    for encoding in ("utf-8-sig", "latin-1"):
+        try:
+            text = content.decode(encoding)
+            break
+        except (UnicodeDecodeError, ValueError):
+            continue
+    if text is None:
+        text = content.decode("utf-8-sig", errors="replace")
 
     # Detect delimiter automatically
     # Try to sniff the delimiter from the first few lines


### PR DESCRIPTION
## What

`download_and_parse_resource` fails with a `UnicodeDecodeError` when parsing CSV files encoded in ISO-8859-1 (Latin-1), such as many French open data files on data.gouv.fr.

**Error:**
```
Error parsing file: 'utf-8' codec can't decode byte 0xe9 in position 16: invalid continuation byte
```

## Why

The `_parse_csv` function hardcodes `content.decode("utf-8-sig")`, which raises `UnicodeDecodeError` for non-UTF-8 files. The byte `0xe9` is the character `é` in Latin-1 encoding, which is invalid in UTF-8.

## How

Added automatic encoding detection with a fallback chain:
1. Try **UTF-8** first (with BOM handling via `utf-8-sig`), preserving current behavior for UTF-8 files
2. Fall back to **Latin-1** (`ISO-8859-1`), which covers accented characters common in French text
3. As a last resort, decode as UTF-8 with `errors="replace"` to avoid crashing entirely

This is a minimal, backwards-compatible change — UTF-8 files continue to work exactly as before, while Latin-1 files now parse correctly instead of raising an error.

Closes #17