### PR TITLE
Validate OpenAPI spec payloads

### DIFF
--- a/helpers/datagouv_api_client.py
+++ b/helpers/datagouv_api_client.py
@@ -174,15 +174,22 @@ async def fetch_openapi_spec(
 
         # Try JSON first, then YAML
         try:
-            return json.loads(content)
+            parsed_json = json.loads(content)
+            if isinstance(parsed_json, dict):
+                return parsed_json
         except (json.JSONDecodeError, ValueError):
             pass
+
         try:
-            return yaml.safe_load(content)
+            parsed_yaml = yaml.safe_load(content)
+            if isinstance(parsed_yaml, dict):
+                return parsed_yaml
         except yaml.YAMLError:
             pass
 
-        raise ValueError(f"Could not parse OpenAPI spec from {url} as JSON or YAML")
+        raise ValueError(
+            f"Could not parse OpenAPI spec from {url} as JSON or YAML object"
+        )
     finally:
         if own:
             await session.aclose()

--- a/tests/test_datagouv_api.py
+++ b/tests/test_datagouv_api.py
@@ -2,6 +2,7 @@
 
 import os
 
+import httpx
 import pytest
 
 from helpers import datagouv_api_client
@@ -220,3 +221,15 @@ class TestAsyncFunctions:
             await datagouv_api_client.fetch_openapi_spec(
                 "https://example.com/nonexistent-spec.json"
             )
+
+    async def test_fetch_openapi_spec_invalid_body(self):
+        """Test that non-dict specs raise a ValueError."""
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text="just some text")
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as session:
+            with pytest.raises(ValueError, match="OpenAPI spec"):
+                await datagouv_api_client.fetch_openapi_spec(
+                    "https://example.com/spec.txt", session=session
+                )


### PR DESCRIPTION
## Summary
- ensure OpenAPI spec parsing only returns mapping objects
- raise a clear error when the spec payload isn't a JSON/YAML object
- add a unit test that covers the invalid-body case

## Problem
fetch_openapi_spec would happily return non-dict payloads (e.g., a plain string), which makes downstream usage fail later and produces confusing errors.

## Reasoning
OpenAPI specs are defined as JSON/YAML objects. Enforcing that early keeps behavior predictable and surfaces bad specs immediately.

## Changes
- validate parsed JSON/YAML is a dict before returning
- tighten the error message when parsing fails
- add a MockTransport test to guard against non-dict specs

## Testing
- uv run pytest tests/test_datagouv_api.py (fails locally: uv not installed)