### PR TITLE
fix: enable stateless HTTP to fix "Session not found" for most MCP clients

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,7 +43,15 @@ transport_security = TransportSecuritySettings(
     ],
 )
 
-mcp = FastMCP("data.gouv.fr MCP server", transport_security=transport_security)
+# Enable stateless_http to avoid "Session not found" errors with MCP clients
+# that don't properly maintain the mcp-session-id header across requests
+# (e.g. Claude Code, Cline, OpenAI Codex). Since this server does not use
+# server-initiated notifications, stateful sessions are not needed.
+mcp = FastMCP(
+    "data.gouv.fr MCP server",
+    transport_security=transport_security,
+    stateless_http=True,
+)
 register_tools(mcp)
 
 


### PR DESCRIPTION
## Problem

Multiple MCP clients fail to maintain the `mcp-session-id` header across requests when using Streamable HTTP transport, causing every tool call to fail with:

```
{"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Session not found"}}
```

### Affected clients (confirmed via GitHub issues)

| Client | Issue | Status |
|--------|-------|--------|
| Claude Code | [anthropics/claude-code#27142](https://github.com/anthropics/claude-code/issues/27142) | Open |
| Claude Code | [anthropics/claude-code#28545](https://github.com/anthropics/claude-code/issues/28545) | Open |
| Claude Code | [anthropics/claude-code#29562](https://github.com/anthropics/claude-code/issues/29562) | Open |
| MCP TypeScript SDK | [modelcontextprotocol/typescript-sdk#812](https://github.com/modelcontextprotocol/typescript-sdk/issues/812) | Open |
| Cline | [cline/cline#6767](https://github.com/cline/cline/issues/6767) | Open |
| OpenAI Codex | [openai/codex#12869](https://github.com/openai/codex/issues/12869) | Open |
| LangChain4j | [langchain4j/langchain4j#3802](https://github.com/langchain4j/langchain4j/issues/3802) | Open |

This was also reported directly on this repo in #25 and #37.

## Root cause

The MCP Streamable HTTP protocol is stateful by default: the server returns an `mcp-session-id` header after `initialize`, and clients must include it in all subsequent requests. Many clients don't do this correctly — they either drop the header or fail to re-initialize after session invalidation.

## Fix

Add `stateless_http=True` to the `FastMCP` constructor. This creates a temporary session per request, eliminating the need for clients to persist session IDs.

```python
# Before
mcp = FastMCP("data.gouv.fr MCP server", transport_security=transport_security)

# After
mcp = FastMCP(
    "data.gouv.fr MCP server",
    transport_security=transport_security,
    stateless_http=True,
)
```

### Why this is safe

- This server is **read-only** and does not use server-initiated notifications or server-to-client requests
- `stateless_http=True` is [supported by FastMCP](https://github.com/jlowin/fastmcp) and [recommended for load-balanced deployments](https://github.com/modelcontextprotocol/python-sdk/issues/1180)
- It also resolves the multi-worker sticky session issue (#25) at the application layer, making the server resilient to any load balancer configuration

### Verification

Tested the full MCP handshake via `curl` — the server already works correctly when session IDs are managed manually. This fix removes the session requirement entirely so that all clients work out of the box.

Refs: #25, #37