### PR TITLE
Docs: Update README with HuggingChat server setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use the hosted endpoint `https://mcp.data.gouv.fr/mcp` (recommended). If you sel
 
 The MCP server configuration depends on your client. Use the appropriate configuration format for your client:
 
-[AnythingLLM](#anythingllm) | [ChatGPT](#chatgpt) | [Claude Code](#claude-code) | [Claude Desktop](#claude-desktop) | [Cursor](#cursor) | [Gemini CLI](#gemini-cli) | [HuggingChat](#huggingchat) | [IBM Bob](#ibm-bob) | [Le Chat (Mistral)](#le-chat-mistral) | [Kiro CLI](#kiro-cli) | [Kiro IDE](#kiro-ide) | [Mistral Vibe](#mistral-vibe-cli) | [VS Code](#vs-code) | [Windsurf](#windsurf)
+[AnythingLLM](#anythingllm) | [ChatGPT](#chatgpt) | [Claude Code](#claude-code) | [Claude Desktop](#claude-desktop) | [Cursor](#cursor) | [Gemini CLI](#gemini-cli) | [HuggingChat](#huggingchat) | [IBM Bob](#ibm-bob) | [Kiro CLI](#kiro-cli) | [Kiro IDE](#kiro-ide) | [Le Chat (Mistral)](#le-chat-mistral) | [Mistral Vibe](#mistral-vibe-cli) | [VS Code](#vs-code) | [Windsurf](#windsurf)
 
 ### AnythingLLM
 


### PR DESCRIPTION
## Contexte
*Contribution spontanée*
HuggingChat supporte désormais les serveurs MCP. L'ajout de ce tutoriel permet à la communauté d'intégrer facilement et rapidement les données de Data.gouv directement dans leurs assistants HuggingChat.

## Modifications apportées
- Mise à jour du fichier `README.md`.
- Ajout d'un tutoriel étape par étape pour configurer le serveur (Settings > Add Server > Configure > Health Check) en respectant le format de documentation existant.