### PR TITLE
fix: allow localhost with port in allowed_hosts for local MCP clients

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,8 +35,8 @@ transport_security = TransportSecuritySettings(
     allowed_hosts=[
         "mcp.data.gouv.fr",
         "mcp.preprod.data.gouv.fr",
-        "localhost",
-        "127.0.0.1",
+        "localhost:*",
+        "127.0.0.1:*",
     ],
     # Validate Origin header to prevent DNS rebinding attacks (MCP spec requirement)
     allowed_origins=[


### PR DESCRIPTION
### Problem

When running the MCP server locally (Docker) and connecting with GitHub Copilot or Claude, the connection fails with:

`421 Invalid Host header`

This happens because MCP clients send:

`Host: 127.0.0.1:8000`

But _allowed_hosts_ only contains:

`"127.0.0.1"`

So the validation fails since the port is included in the Host header.

### Solution

Allow wildcard ports for local development:

"localhost:*",
"127.0.0.1:*",

This preserves DNS rebinding protection while allowing legitimate local usage.

### Security considerations

DNS rebinding protection remains enabled.

Only localhost is expanded to allow dynamic ports.

Production domains remain unchanged.