### PR TITLE
refactor: replace per-call httpx clients with module-level singletons

### DIFF
--- a/helpers/crawler_api_client.py
+++ b/helpers/crawler_api_client.py
@@ -10,19 +10,12 @@ from helpers.user_agent import USER_AGENT
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
+_client = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
+
 # Cache for the exceptions list
 _exceptions_cache: set[str] | None = None
 _cache_timestamp: float = 0
 CACHE_TTL_SECONDS: float = 3600.0  # 1 hour
-
-
-async def _get_session(
-    session: httpx.AsyncClient | None,
-) -> tuple[httpx.AsyncClient, bool]:
-    if session is not None:
-        return session, False
-    new_session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
-    return new_session, True
 
 
 async def fetch_resource_exceptions(
@@ -57,14 +50,14 @@ async def fetch_resource_exceptions(
         logger.debug("Using cached exceptions list (%d items)", len(_exceptions_cache))
         return _exceptions_cache
 
-    sess, owns_session = await _get_session(session)
+    client = session or _client
     try:
         base_url: str = env_config.get_base_url("crawler_api")
         url = f"{base_url}resources-exceptions"
 
         logger.info(f"Crawler API: Fetching resource exceptions from {url}")
 
-        resp = await sess.get(url, timeout=30.0)
+        resp = await client.get(url, timeout=30.0)
         resp.raise_for_status()
 
         data: list[dict[str, Any]] = resp.json()
@@ -92,9 +85,6 @@ async def fetch_resource_exceptions(
             return _exceptions_cache
         # Return empty set if no cache available
         return set()
-    finally:
-        if owns_session:
-            await sess.aclose()
 
 
 async def is_in_exceptions_list(

--- a/helpers/datagouv_api_client.py
+++ b/helpers/datagouv_api_client.py
@@ -11,6 +11,8 @@ from helpers.user_agent import USER_AGENT
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
+_client = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
+
 
 async def _fetch_json(client: httpx.AsyncClient, url: str) -> dict[str, Any]:
     logger.debug("datagouv API GET %s", url)
@@ -29,38 +31,24 @@ async def get_resource_details(
     """
     Fetch the complete resource payload from the API v2 endpoint.
     """
-    own = session is None
-    if own:
-        session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
-    assert session is not None
-    try:
-        base_url: str = env_config.get_base_url("datagouv_api")
-        url = f"{base_url}2/datasets/resources/{resource_id}/"
-        return await _fetch_json(session, url)
-    finally:
-        if own:
-            await session.aclose()
+    client = session or _client
+    base_url: str = env_config.get_base_url("datagouv_api")
+    url = f"{base_url}2/datasets/resources/{resource_id}/"
+    return await _fetch_json(client, url)
 
 
 async def get_resource_metadata(
     resource_id: str, session: httpx.AsyncClient | None = None
 ) -> dict[str, Any]:
-    own = session is None
-    if own:
-        session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
-    assert session is not None
-    try:
-        data = await get_resource_details(resource_id, session=session)
-        resource: dict[str, Any] = data.get("resource", {})
-        return {
-            "id": resource.get("id") or resource_id,
-            "title": resource.get("title") or resource.get("name"),
-            "description": resource.get("description"),
-            "dataset_id": data.get("dataset_id"),
-        }
-    finally:
-        if own:
-            await session.aclose()
+    client = session or _client
+    data = await get_resource_details(resource_id, session=client)
+    resource: dict[str, Any] = data.get("resource", {})
+    return {
+        "id": resource.get("id") or resource_id,
+        "title": resource.get("title") or resource.get("name"),
+        "description": resource.get("description"),
+        "dataset_id": data.get("dataset_id"),
+    }
 
 
 async def get_dataset_details(
@@ -69,55 +57,35 @@ async def get_dataset_details(
     """
     Fetch the complete dataset payload from the API v1 endpoint.
     """
-    own = session is None
-    if own:
-        session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
-    assert session is not None
-    try:
-        base_url: str = env_config.get_base_url("datagouv_api")
-        url = f"{base_url}1/datasets/{dataset_id}/"
-        return await _fetch_json(session, url)
-    finally:
-        if own:
-            await session.aclose()
+    client = session or _client
+    base_url: str = env_config.get_base_url("datagouv_api")
+    url = f"{base_url}1/datasets/{dataset_id}/"
+    return await _fetch_json(client, url)
 
 
 async def get_dataset_metadata(
     dataset_id: str, session: httpx.AsyncClient | None = None
 ) -> dict[str, Any]:
-    own = session is None
-    if own:
-        session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
-    assert session is not None
-    try:
-        data = await get_dataset_details(dataset_id, session=session)
-        return {
-            "id": data.get("id"),
-            "title": data.get("title") or data.get("name"),
-            "description_short": data.get("description_short"),
-            "description": data.get("description"),
-        }
-    finally:
-        if own:
-            await session.aclose()
+    client = session or _client
+    data = await get_dataset_details(dataset_id, session=client)
+    return {
+        "id": data.get("id"),
+        "title": data.get("title") or data.get("name"),
+        "description_short": data.get("description_short"),
+        "description": data.get("description"),
+    }
 
 
 async def get_resource_and_dataset_metadata(
     resource_id: str, session: httpx.AsyncClient | None = None
 ) -> dict[str, Any]:
-    own = session is None
-    if own:
-        session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
-    try:
-        res: dict[str, Any] = await get_resource_metadata(resource_id, session=session)
-        ds: dict[str, Any] = {}
-        ds_id = res.get("dataset_id")
-        if ds_id:
-            ds = await get_dataset_metadata(str(ds_id), session=session)
-        return {"resource": res, "dataset": ds}
-    finally:
-        if own and session:
-            await session.aclose()
+    client = session or _client
+    res: dict[str, Any] = await get_resource_metadata(resource_id, session=client)
+    ds: dict[str, Any] = {}
+    ds_id = res.get("dataset_id")
+    if ds_id:
+        ds = await get_dataset_metadata(str(ds_id), session=client)
+    return {"resource": res, "dataset": ds}
 
 
 async def get_resources_for_dataset(
@@ -129,25 +97,18 @@ async def get_resources_for_dataset(
     Returns:
         dict with 'dataset' metadata and 'resources' list of resource IDs and titles
     """
-    own = session is None
-    if own:
-        session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
-    try:
-        ds = await get_dataset_metadata(dataset_id, session=session)
-        base_url: str = env_config.get_base_url("datagouv_api")
-        # Fetch resources from API v1
-        url = f"{base_url}1/datasets/{dataset_id}/"
-        data = await _fetch_json(session, url)  # type: ignore
-        resources: list[dict[str, Any]] = data.get("resources", [])
-        res_list: list[tuple[str, str]] = [
-            (res.get("id"), res.get("title", "") or res.get("name", ""))
-            for res in resources
-            if res.get("id")
-        ]
-        return {"dataset": ds, "resources": res_list}
-    finally:
-        if own and session:
-            await session.aclose()
+    client = session or _client
+    ds = await get_dataset_metadata(dataset_id, session=client)
+    base_url: str = env_config.get_base_url("datagouv_api")
+    url = f"{base_url}1/datasets/{dataset_id}/"
+    data = await _fetch_json(client, url)
+    resources: list[dict[str, Any]] = data.get("resources", [])
+    res_list: list[tuple[str, str]] = [
+        (res.get("id"), res.get("title", "") or res.get("name", ""))
+        for res in resources
+        if res.get("id")
+    ]
+    return {"dataset": ds, "resources": res_list}
 
 
 async def fetch_openapi_spec(
@@ -164,30 +125,22 @@ async def fetch_openapi_spec(
         httpx.HTTPError: If the HTTP request fails.
         ValueError: If the response cannot be parsed as JSON or YAML.
     """
-    own = session is None
-    if own:
-        session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
-    assert session is not None
+    client = session or _client
+    logger.debug("Fetching OpenAPI spec from %s", url)
+    resp = await client.get(url, timeout=15.0, follow_redirects=True)
+    resp.raise_for_status()
+    content = resp.text
+
     try:
-        logger.debug("Fetching OpenAPI spec from %s", url)
-        resp = await session.get(url, timeout=15.0, follow_redirects=True)
-        resp.raise_for_status()
-        content = resp.text
+        return json.loads(content)
+    except (json.JSONDecodeError, ValueError):
+        pass
+    try:
+        return yaml.safe_load(content)
+    except yaml.YAMLError:
+        pass
 
-        # Try JSON first, then YAML
-        try:
-            return json.loads(content)
-        except (json.JSONDecodeError, ValueError):
-            pass
-        try:
-            return yaml.safe_load(content)
-        except yaml.YAMLError:
-            pass
-
-        raise ValueError(f"Could not parse OpenAPI spec from {url} as JSON or YAML")
-    finally:
-        if own:
-            await session.aclose()
+    raise ValueError(f"Could not parse OpenAPI spec from {url} as JSON or YAML")
 
 
 async def get_dataservice_details(
@@ -196,17 +149,10 @@ async def get_dataservice_details(
     """
     Fetch the complete dataservice payload from the API v1 endpoint.
     """
-    own = session is None
-    if own:
-        session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
-    assert session is not None
-    try:
-        base_url: str = env_config.get_base_url("datagouv_api")
-        url = f"{base_url}1/dataservices/{dataservice_id}/"
-        return await _fetch_json(session, url)
-    finally:
-        if own:
-            await session.aclose()
+    client = session or _client
+    base_url: str = env_config.get_base_url("datagouv_api")
+    url = f"{base_url}1/dataservices/{dataservice_id}/"
+    return await _fetch_json(client, url)
 
 
 async def search_dataservices(
@@ -226,56 +172,49 @@ async def search_dataservices(
     Returns:
         dict with 'data' (list of dataservices), 'page', 'page_size', and 'total'
     """
-    own = session is None
-    if own:
-        session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
-    assert session is not None
-    try:
-        base_url: str = env_config.get_base_url("datagouv_api")
-        url = f"{base_url}2/dataservices/search/"
-        params = {
-            "q": query,
-            "page": page,
-            "page_size": min(page_size, 100),
-        }
-        resp = await session.get(url, params=params, timeout=15.0)
-        resp.raise_for_status()
-        data = resp.json()
+    client = session or _client
+    base_url: str = env_config.get_base_url("datagouv_api")
+    url = f"{base_url}2/dataservices/search/"
+    params = {
+        "q": query,
+        "page": page,
+        "page_size": min(page_size, 100),
+    }
+    resp = await client.get(url, params=params, timeout=15.0)
+    resp.raise_for_status()
+    data = resp.json()
 
-        dataservices: list[dict[str, Any]] = data.get("data", [])
-        results: list[dict[str, Any]] = []
-        for ds in dataservices:
-            tags: list[str] = []
-            for tag in ds.get("tags", []):
-                if isinstance(tag, str):
-                    tags.append(tag)
-                elif isinstance(tag, dict):
-                    tags.append(tag.get("name", ""))
+    dataservices: list[dict[str, Any]] = data.get("data", [])
+    results: list[dict[str, Any]] = []
+    for ds in dataservices:
+        tags: list[str] = []
+        for tag in ds.get("tags", []):
+            if isinstance(tag, str):
+                tags.append(tag)
+            elif isinstance(tag, dict):
+                tags.append(tag.get("name", ""))
 
-            results.append(
-                {
-                    "id": ds.get("id"),
-                    "title": ds.get("title") or "",
-                    "description": ds.get("description", ""),
-                    "organization": ds.get("organization", {}).get("name")
-                    if ds.get("organization")
-                    else None,
-                    "base_api_url": ds.get("base_api_url"),
-                    "machine_documentation_url": ds.get("machine_documentation_url"),
-                    "tags": tags,
-                    "url": f"{env_config.get_base_url('site')}dataservices/{ds.get('id', '')}",
-                }
-            )
+        results.append(
+            {
+                "id": ds.get("id"),
+                "title": ds.get("title") or "",
+                "description": ds.get("description", ""),
+                "organization": ds.get("organization", {}).get("name")
+                if ds.get("organization")
+                else None,
+                "base_api_url": ds.get("base_api_url"),
+                "machine_documentation_url": ds.get("machine_documentation_url"),
+                "tags": tags,
+                "url": f"{env_config.get_base_url('site')}dataservices/{ds.get('id', '')}",
+            }
+        )
 
-        return {
-            "data": results,
-            "page": page,
-            "page_size": len(results),
-            "total": data.get("total", len(results)),
-        }
-    finally:
-        if own:
-            await session.aclose()
+    return {
+        "data": results,
+        "page": page,
+        "page_size": len(results),
+        "total": data.get("total", len(results)),
+    }
 
 
 async def search_datasets(
@@ -295,57 +234,47 @@ async def search_datasets(
     Returns:
         dict with 'data' (list of datasets), 'page', 'page_size', and 'total'
     """
-    own = session is None
-    if own:
-        session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
-    assert session is not None
-    try:
-        base_url: str = env_config.get_base_url("datagouv_api")
-        # Use API v2 for dataset search
-        url = f"{base_url}2/datasets/search/"
-        params = {
-            "q": query,
-            "page": page,
-            "page_size": min(page_size, 100),  # API limit
-        }
-        resp = await session.get(url, params=params, timeout=15.0)
-        resp.raise_for_status()
-        data = resp.json()
+    client = session or _client
+    base_url: str = env_config.get_base_url("datagouv_api")
+    url = f"{base_url}2/datasets/search/"
+    params = {
+        "q": query,
+        "page": page,
+        "page_size": min(page_size, 100),
+    }
+    resp = await client.get(url, params=params, timeout=15.0)
+    resp.raise_for_status()
+    data = resp.json()
 
-        datasets: list[dict[str, Any]] = data.get("data", [])
-        # Extract relevant fields for each dataset
-        results: list[dict[str, Any]] = []
-        for ds in datasets:
-            # Handle tags - can be strings or objects with "name" field
-            tags: list[str] = []
-            for tag in ds.get("tags", []):
-                if isinstance(tag, str):
-                    tags.append(tag)
-                elif isinstance(tag, dict):
-                    tags.append(tag.get("name", ""))
+    datasets: list[dict[str, Any]] = data.get("data", [])
+    results: list[dict[str, Any]] = []
+    for ds in datasets:
+        tags: list[str] = []
+        for tag in ds.get("tags", []):
+            if isinstance(tag, str):
+                tags.append(tag)
+            elif isinstance(tag, dict):
+                tags.append(tag.get("name", ""))
 
-            results.append(
-                {
-                    "id": ds.get("id"),
-                    "title": ds.get("title") or ds.get("name", ""),
-                    "description": ds.get("description", ""),
-                    "description_short": ds.get("description_short", ""),
-                    "slug": ds.get("slug", ""),
-                    "organization": ds.get("organization", {}).get("name")
-                    if ds.get("organization")
-                    else None,
-                    "tags": tags,
-                    "resources_count": len(ds.get("resources", [])),
-                    "url": f"{env_config.get_base_url('site')}datasets/{ds.get('slug', ds.get('id', ''))}",
-                }
-            )
+        results.append(
+            {
+                "id": ds.get("id"),
+                "title": ds.get("title") or ds.get("name", ""),
+                "description": ds.get("description", ""),
+                "description_short": ds.get("description_short", ""),
+                "slug": ds.get("slug", ""),
+                "organization": ds.get("organization", {}).get("name")
+                if ds.get("organization")
+                else None,
+                "tags": tags,
+                "resources_count": len(ds.get("resources", [])),
+                "url": f"{env_config.get_base_url('site')}datasets/{ds.get('slug', ds.get('id', ''))}",
+            }
+        )
 
-        return {
-            "data": results,
-            "page": page,
-            "page_size": len(results),
-            "total": data.get("total", len(results)),
-        }
-    finally:
-        if own:
-            await session.aclose()
+    return {
+        "data": results,
+        "page": page,
+        "page_size": len(results),
+        "total": data.get("total", len(results)),
+    }

--- a/helpers/metrics_api_client.py
+++ b/helpers/metrics_api_client.py
@@ -9,14 +9,7 @@ from helpers.user_agent import USER_AGENT
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
-
-async def _get_session(
-    session: httpx.AsyncClient | None,
-) -> tuple[httpx.AsyncClient, bool]:
-    if session is not None:
-        return session, False
-    new_session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
-    return new_session, True
+_client = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
 
 
 async def get_metrics(
@@ -59,28 +52,24 @@ async def get_metrics(
         )
 
     time_field: str = f"metric_{time_granularity}"
-    sess, owns_session = await _get_session(session)
-    try:
-        base_url: str = env_config.get_base_url("metrics_api")
-        url = f"{base_url}{model}/data/"
-        params = {
-            f"{id_field}__exact": id_value,
-            f"{time_field}__sort": sort_order,
-            "page_size": max(1, min(limit, 100)),
-        }
-        logger.debug(
-            f"Fetching metrics from {url} with params: {id_field}__exact={id_value}, "
-            f"{time_field}__sort={sort_order}, page_size={params['page_size']}"
-        )
-        resp = await sess.get(url, params=params, timeout=20.0)
-        resp.raise_for_status()
-        payload = resp.json()
-        data: list[dict[str, Any]] = payload.get("data", [])
-        logger.debug(f"Received {len(data)} metric entries from API")
-        return data
-    finally:
-        if owns_session:
-            await sess.aclose()
+    client = session or _client
+    base_url: str = env_config.get_base_url("metrics_api")
+    url = f"{base_url}{model}/data/"
+    params = {
+        f"{id_field}__exact": id_value,
+        f"{time_field}__sort": sort_order,
+        "page_size": max(1, min(limit, 100)),
+    }
+    logger.debug(
+        f"Fetching metrics from {url} with params: {id_field}__exact={id_value}, "
+        f"{time_field}__sort={sort_order}, page_size={params['page_size']}"
+    )
+    resp = await client.get(url, params=params, timeout=20.0)
+    resp.raise_for_status()
+    payload = resp.json()
+    data: list[dict[str, Any]] = payload.get("data", [])
+    logger.debug(f"Received {len(data)} metric entries from API")
+    return data
 
 
 async def get_metrics_csv(
@@ -124,21 +113,17 @@ async def get_metrics_csv(
         )
 
     time_field: str = f"metric_{time_granularity}"
-    sess, owns_session = await _get_session(session)
-    try:
-        base_url: str = env_config.get_base_url("metrics_api")
-        url = f"{base_url}{model}/data/csv/"
-        params = {
-            f"{id_field}__exact": id_value,
-            f"{time_field}__sort": sort_order,
-        }
-        logger.debug(
-            f"Fetching metrics CSV from {url} with params: {id_field}__exact={id_value}, "
-            f"{time_field}__sort={sort_order}"
-        )
-        resp = await sess.get(url, params=params, timeout=30.0)
-        resp.raise_for_status()
-        return resp.text
-    finally:
-        if owns_session:
-            await sess.aclose()
+    client = session or _client
+    base_url: str = env_config.get_base_url("metrics_api")
+    url = f"{base_url}{model}/data/csv/"
+    params = {
+        f"{id_field}__exact": id_value,
+        f"{time_field}__sort": sort_order,
+    }
+    logger.debug(
+        f"Fetching metrics CSV from {url} with params: {id_field}__exact={id_value}, "
+        f"{time_field}__sort={sort_order}"
+    )
+    resp = await client.get(url, params=params, timeout=30.0)
+    resp.raise_for_status()
+    return resp.text

--- a/helpers/tabular_api_client.py
+++ b/helpers/tabular_api_client.py
@@ -9,18 +9,11 @@ from helpers.user_agent import USER_AGENT
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
+_client = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
+
 
 class ResourceNotAvailableError(Exception):
     """Raised when a resource is not available via the Tabular API."""
-
-
-async def _get_session(
-    session: httpx.AsyncClient | None,
-) -> tuple[httpx.AsyncClient, bool]:
-    if session is not None:
-        return session, False
-    new_session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
-    return new_session, True
 
 
 async def fetch_resource_data(
@@ -34,42 +27,38 @@ async def fetch_resource_data(
     """
     Fetch data for a resource via the Tabular API.
     """
-    sess, owns_session = await _get_session(session)
-    try:
-        base_url: str = env_config.get_base_url("tabular_api")
-        url = f"{base_url}resources/{resource_id}/data/"
-        query_params = {
-            "page": max(page, 1),
-            "page_size": max(page_size, 1),
-        }
-        if params:
-            query_params.update(params)
+    client = session or _client
+    base_url: str = env_config.get_base_url("tabular_api")
+    url = f"{base_url}resources/{resource_id}/data/"
+    query_params = {
+        "page": max(page, 1),
+        "page_size": max(page_size, 1),
+    }
+    if params:
+        query_params.update(params)
 
-        full_url = f"{url}?{'&'.join(f'{k}={v}' for k, v in query_params.items())}"
-        logger.info(
-            f"Tabular API: Fetching resource data - URL: {full_url}, "
-            f"resource_id: {resource_id}"
+    full_url = f"{url}?{'&'.join(f'{k}={v}' for k, v in query_params.items())}"
+    logger.info(
+        f"Tabular API: Fetching resource data - URL: {full_url}, "
+        f"resource_id: {resource_id}"
+    )
+
+    resp = await client.get(url, params=query_params, timeout=30.0)
+    if resp.status_code == 404:
+        logger.warning(f"Tabular API: Resource {resource_id} not found (404)")
+        raise ResourceNotAvailableError(
+            f"Resource {resource_id} not available via Tabular API"
         )
 
-        resp = await sess.get(url, params=query_params, timeout=30.0)
-        if resp.status_code == 404:
-            logger.warning(f"Tabular API: Resource {resource_id} not found (404)")
-            raise ResourceNotAvailableError(
-                f"Resource {resource_id} not available via Tabular API"
-            )
+    if resp.status_code >= 400:
+        error_body = resp.text
+        logger.error(
+            f"Tabular API: Error {resp.status_code} for resource {resource_id} - "
+            f"Response: {error_body[:500]}"
+        )
 
-        if resp.status_code >= 400:
-            error_body = resp.text
-            logger.error(
-                f"Tabular API: Error {resp.status_code} for resource {resource_id} - "
-                f"Response: {error_body[:500]}"
-            )
-
-        resp.raise_for_status()
-        return resp.json()
-    finally:
-        if owns_session:
-            await sess.aclose()
+    resp.raise_for_status()
+    return resp.json()
 
 
 async def fetch_resource_profile(
@@ -80,43 +69,36 @@ async def fetch_resource_profile(
     """
     Fetch the profile metadata for a resource via the Tabular API.
     """
+    client = session or _client
+    base_url: str = env_config.get_base_url("tabular_api")
+    url = f"{base_url}resources/{resource_id}/profile/"
+    logger.debug(
+        f"Tabular API: Fetching resource profile - URL: {url}, "
+        f"resource_id: {resource_id}"
+    )
 
-    sess, owns_session = await _get_session(session)
-    try:
-        base_url: str = env_config.get_base_url("tabular_api")
-        url = f"{base_url}resources/{resource_id}/profile/"
-        logger.debug(
-            f"Tabular API: Fetching resource profile - URL: {url}, "
-            f"resource_id: {resource_id}"
+    resp = await client.get(url, timeout=30.0)
+    if resp.status_code == 404:
+        logger.warning(f"Tabular API: Resource profile {resource_id} not found (404)")
+        raise ResourceNotAvailableError(
+            f"Resource {resource_id} profile not available via Tabular API"
         )
 
-        resp = await sess.get(url, timeout=30.0)
-        if resp.status_code == 404:
-            logger.warning(
-                f"Tabular API: Resource profile {resource_id} not found (404)"
-            )
-            raise ResourceNotAvailableError(
-                f"Resource {resource_id} profile not available via Tabular API"
-            )
+    if resp.status_code >= 400:
+        error_body = resp.text
+        logger.error(
+            f"Tabular API: Profile error {resp.status_code} for resource {resource_id} - "
+            f"Response: {error_body[:500]}"
+        )
 
-        if resp.status_code >= 400:
-            error_body = resp.text
-            logger.error(
-                f"Tabular API: Profile error {resp.status_code} for resource {resource_id} - "
-                f"Response: {error_body[:500]}"
-            )
+    resp.raise_for_status()
+    profile_data: dict[str, Any] = resp.json()
 
-        resp.raise_for_status()
-        profile_data: dict[str, Any] = resp.json()
+    # Clean up headers: remove surrounding quotes if present
+    if "profile" in profile_data and "header" in profile_data["profile"]:
+        profile_data["profile"]["header"] = [
+            header.strip('"') if isinstance(header, str) else header
+            for header in profile_data["profile"]["header"]
+        ]
 
-        # Clean up headers: remove surrounding quotes if present
-        if "profile" in profile_data and "header" in profile_data["profile"]:
-            profile_data["profile"]["header"] = [
-                header.strip('"') if isinstance(header, str) else header
-                for header in profile_data["profile"]["header"]
-            ]
-
-        return profile_data
-    finally:
-        if owns_session:
-            await sess.aclose()
+    return profile_data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ extend-select = ["I"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]

--- a/tests/test_datagouv_api.py
+++ b/tests/test_datagouv_api.py
@@ -1,7 +1,7 @@
 """Tests for the datagouv_api_client helper."""
 
 import os
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -23,6 +23,11 @@ def known_resource_id() -> str:
     return "3b6b2281-b9d9-4959-ae9d-c2c166dff118"
 
 
+def test_module_client_has_user_agent():
+    """Test that the shared httpx client is configured with the correct User-Agent header."""
+    assert datagouv_api_client._client.headers.get("user-agent") == USER_AGENT
+
+
 @pytest.mark.asyncio
 class TestAsyncFunctions:
     """Tests for async API functions."""
@@ -36,8 +41,10 @@ class TestAsyncFunctions:
         assert "title" in metadata
         assert metadata["title"] is not None
 
-    async def test_get_dataset_metadata_sends_user_agent(self, known_dataset_id):
-        """Test that get_dataset_metadata creates a client with User-Agent header."""
+    async def test_get_dataset_metadata_accepts_session_override(
+        self, known_dataset_id
+    ):
+        """Test that get_dataset_metadata uses an injected session when provided."""
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.json.return_value = {
@@ -46,17 +53,12 @@ class TestAsyncFunctions:
         }
         mock_response.raise_for_status = MagicMock()
         mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.aclose = AsyncMock(return_value=None)
 
-        with patch(
-            "helpers.datagouv_api_client.httpx.AsyncClient",
-            return_value=mock_client,
-        ) as mock_async_client:
-            await datagouv_api_client.get_dataset_metadata(
-                known_dataset_id, session=None
-            )
+        await datagouv_api_client.get_dataset_metadata(
+            known_dataset_id, session=mock_client
+        )
 
-        mock_async_client.assert_called_once_with(headers={"User-Agent": USER_AGENT})
+        mock_client.get.assert_called_once()
 
     async def test_get_resource_metadata(self, known_resource_id):
         """Test fetching resource metadata."""


### PR DESCRIPTION
Related to [#86](https://github.com/datagouv/datagouv-mcp/issues/86).

`httpx.AsyncClient` is costly to spin up and tear down on every request: HTTPS repeats TLS handshakes and SSL context work. Clients are closed in `finally` today, so this is not a leak, but repeating this cycle _**may**_ still cost CPU and memory under high load.

When removing Matomo httpx clients, production then saw fewer OOM-related restarts (see [#86](https://github.com/datagouv/datagouv-mcp/issues/86)). 
[#88](https://github.com/datagouv/datagouv-mcp/pull/88) used one shared client for Matomo to try to solve this issue, reducing the number of short-lived clients.
If that helps reducing memory overhead, then sharing clients for the API helpers could reduce similar overhead the same way. This PR applies the same idea for the remaining API clients.

## Profiling

Memray on ~40 outbound calls in one short LLM session showed ~295 MB cumulative SSL-related allocations with the old per-call pattern.
Most of that is transient, so a local profiling didn't prove production wins, but we hope connection pooling lowers that work under real traffic.

## Significant Changes

- one module-level `AsyncClient` per helper with pooled connections
- optional `session` unchanged for tests
- `pytest-asyncio` session-scoped event loop so teardown does not hit `"event loop is closed"`.

We do not know yet that this alone fixes [#86](https://github.com/datagouv/datagouv-mcp/issues/86), please treat it as a reasonable follow-up to #88 and validate with prod traffic metrics.
