### PR TITLE
Use api v2 for search

### DIFF
--- a/helpers/datagouv_api_client.py
+++ b/helpers/datagouv_api_client.py
@@ -231,7 +231,7 @@ async def search_dataservices(
     assert session is not None
     try:
         base_url: str = env_config.get_base_url("datagouv_api")
-        url = f"{base_url}1/dataservices/"
+        url = f"{base_url}2/dataservices/search/"
         params = {
             "q": query,
             "page": page,
@@ -300,8 +300,8 @@ async def search_datasets(
     assert session is not None
     try:
         base_url: str = env_config.get_base_url("datagouv_api")
-        # Use API v1 for dataset search
-        url = f"{base_url}1/datasets/"
+        # Use API v2 for dataset search
+        url = f"{base_url}2/datasets/search/"
         params = {
             "q": query,
             "page": page,


### PR DESCRIPTION
api v1 [uses a simple mongo full text](https://github.com/bjperson/udata/blob/32b13ace4e0cb390c53595a7d5abb8901b65ca28/udata/core/dataset/api.py#L171) on title only. It is mostly used for listing and not searching.
api v2 [uses ES search](https://github.com/opendatateam/udata-search-service) with full text search analyzer, tokenization and ranking.

See results on [v1](https://www.data.gouv.fr/api/1/datasets/?q=M%C3%A9t%C3%A9o-France+donn%C3%A9es+observations+stations&page=1&page_size=20) VS [v2](https://www.data.gouv.fr/api/2/datasets/search/?q=M%C3%A9t%C3%A9o-France+donn%C3%A9es+observations+stations&page=1&page_size=20) for `Météo-France données observations stations`.

Payload is similar with the main difference being that datasets don't have resources embedded in payload on api v2.