### PR TITLE
Fix: handle None values in metrics to prevent TypeError

### DIFF
--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -163,3 +163,47 @@ async def test_get_metrics_csv_with_custom_params():
     assert len(csv_content) > 0
     lines = csv_content.strip().split("\n")
     assert len(lines) > 1  # Header + data rows
+
+
+@pytest.mark.asyncio
+async def test_get_metrics_with_none_values_dataset():
+    """Test that None values in metrics are handled gracefully (defaulting to 0)."""
+    known_dataset_id = os.getenv("TEST_DATASET_ID", "55e4129788ee386899a46ec1")
+
+    # This integration test ensures the API response with None values doesn't crash
+    metrics = await metrics_api_client.get_metrics(
+        "datasets",
+        known_dataset_id,
+        limit=5,
+    )
+
+    # If any visits/downloads are None, they should be coerced to 0
+    for entry in metrics:
+        visits = entry.get("monthly_visit", 0) or 0
+        downloads = entry.get("monthly_download_resource", 0) or 0
+
+        assert isinstance(visits, int), "visits should be an int"
+        assert isinstance(downloads, int), "downloads should be an int"
+        assert visits >= 0, "visits should be non-negative"
+        assert downloads >= 0, "downloads should be non-negative"
+
+
+@pytest.mark.asyncio
+async def test_get_metrics_with_none_values_resource():
+    """Test that None values in resource metrics are handled gracefully."""
+    known_resource_id = os.getenv(
+        "TEST_RESOURCE_ID",
+        "3b6b2281-b9d9-4959-ae9d-c2c166dff118",
+    )
+
+    metrics = await metrics_api_client.get_metrics(
+        "resources",
+        known_resource_id,
+        limit=5,
+    )
+
+    # Ensure downloads are properly coerced to int even if None
+    for entry in metrics:
+        downloads = entry.get("monthly_download_resource", 0) or 0
+        assert isinstance(downloads, int), "downloads should be an int"
+        assert downloads >= 0, "downloads should be non-negative"

--- a/tools/get_metrics.py
+++ b/tools/get_metrics.py
@@ -87,8 +87,8 @@ def register_get_metrics_tool(mcp: FastMCP) -> None:
                         total_downloads = 0
                         for entry in metrics:
                             month = entry.get("metric_month", "Unknown")
-                            visits = entry.get("monthly_visit", 0)
-                            downloads = entry.get("monthly_download_resource", 0)
+                            visits = entry.get("monthly_visit", 0) or 0
+                            downloads = entry.get("monthly_download_resource", 0) or 0
                             total_visits += visits
                             total_downloads += downloads
                             content_parts.append(
@@ -153,7 +153,7 @@ def register_get_metrics_tool(mcp: FastMCP) -> None:
                         total_downloads = 0
                         for entry in metrics:
                             month = entry.get("metric_month", "Unknown")
-                            downloads = entry.get("monthly_download_resource", 0)
+                            downloads = entry.get("monthly_download_resource", 0) or 0
                             total_downloads += downloads
                             content_parts.append(f"{month:<12} {downloads:<15,}")
 


### PR DESCRIPTION
this changes resolves #76 by setting None values to 0 