### PR TITLE
fix(logging): import logger name var

### DIFF
--- a/helpers/matomo.py
+++ b/helpers/matomo.py
@@ -3,6 +3,7 @@ import os
 from datetime import UTC, datetime
 
 import httpx
+from helpers.logging import MAIN_LOGGER_NAME
 
 # Configure Matomo
 MATOMO_URL = "https://stats.data.gouv.fr"


### PR DESCRIPTION
A constant import was missed when updating the logging, it could make Matomo tracking fail silently. Corrected in this PR.