### PR TITLE
feat(matomo): configurable Matomo URL and opt-out when unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@ MCP_ENV="local"
 DATAGOUV_API_ENV="prod"
 LOG_LEVEL="INFO"
 
-# Matomo tracking
+# Matomo tracking — set MATOMO_URL and MATOMO_SITE_ID to enable; leave both unset (or empty) to disable
+# MATOMO_URL="https://matomo.example.org"
 # MATOMO_SITE_ID="1"
 # MATOMO_AUTH_TOKEN="1234567890"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - MCP_HOST=${MCP_HOST:-0.0.0.0}
       - MCP_PORT=${MCP_PORT:-8000}
       - DATAGOUV_API_ENV=${DATAGOUV_API_ENV:-prod}
+      - MATOMO_URL=${MATOMO_URL}
       - MATOMO_SITE_ID=${MATOMO_SITE_ID}
       - MATOMO_AUTH_TOKEN=${MATOMO_AUTH_TOKEN}
     restart: unless-stopped

--- a/helpers/matomo.py
+++ b/helpers/matomo.py
@@ -7,7 +7,7 @@ import httpx
 from helpers.logging import MAIN_LOGGER_NAME
 
 # Configure Matomo
-MATOMO_URL = "https://stats.data.gouv.fr"
+MATOMO_URL = os.getenv("MATOMO_URL")
 MATOMO_SITE_ID = os.getenv("MATOMO_SITE_ID")
 MATOMO_AUTH_TOKEN = os.getenv("MATOMO_AUTH")
 
@@ -16,8 +16,9 @@ async def track_matomo(url: str, path: str, headers: dict[str, str]) -> None:
     """
     Sends an asynchronous tracking request to Matomo.
     Fired in the background to avoid blocking the MCP server response.
+    Skipped when MATOMO_URL or MATOMO_SITE_ID is unset.
     """
-    if not MATOMO_SITE_ID:
+    if not MATOMO_URL or not MATOMO_SITE_ID:
         return
 
     # Extract user-agent for better Matomo analytics


### PR DESCRIPTION
Deployments and local setups may need to point analytics at different Matomo hosts, and many environments should not send tracking at all. The server now reads the Matomo base URL from the environment and skips tracking when it or the site id is missing, so omitting configuration cleanly disables analytics instead of failing requests against a hardcoded endpoint.

Docker Compose forwards `MATOMO_URL` into the container alongside the existing Matomo-related variables.