### PR TITLE
fix(tabular): handle Tabular API 4xx/5xx with LLM hints

### DIFF
--- a/helpers/tabular_api_client.py
+++ b/helpers/tabular_api_client.py
@@ -42,12 +42,9 @@ class TabularApiRequestError(Exception):
     """Raised when the Tabular API returns a non-success response (other than 404)."""
 
 
-def _optional_column_hint(body: str) -> str | None:
-    try:
-        payload: object = json.loads(body)
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(payload, dict):
+def _optional_column_hint(payload: dict[str, Any] | None) -> str | None:
+    """If the first Tabular API error looks like a missing column, return a user hint."""
+    if payload is None:
         return None
     errors = payload.get("errors")
     if not isinstance(errors, list) or not errors:
@@ -61,6 +58,30 @@ def _optional_column_hint(body: str) -> str | None:
         if isinstance(msg, str) and "does not exist" in msg.lower():
             return MSG_TABULAR_COLUMN_HINT
     return None
+
+
+def _tabular_error_payload_and_messages(
+    body: str,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    """Parse `body` once (same string as logged); return JSON dict and API detail messages.
+
+    Expects Tabular-style JSON: ``errors[*].detail.message`` strings. Non-JSON bodies
+    return ``(None, [])`` so callers can still raise a generic error.
+    """
+    try:
+        data: object = json.loads(body)
+    except json.JSONDecodeError:
+        return None, []
+    if not isinstance(data, dict):
+        return None, []
+
+    error_msgs: list[str] = []
+    for error in data["errors"]:
+        m = error["detail"]["message"]
+        s = m.strip()
+        if s:
+            error_msgs.append(s)
+    return data, error_msgs
 
 
 def _raise_for_tabular_failure(
@@ -83,10 +104,18 @@ def _raise_for_tabular_failure(
             "If the problem persists, try again in about one minute."
         )
 
-    hint = _optional_column_hint(body)
+    payload, error_msgs = _tabular_error_payload_and_messages(body)
+    hint = _optional_column_hint(payload)
+
     msg = MSG_TABULAR_BAD_REQUEST
     if hint:
         msg = f"{msg} {hint}"
+    if error_msgs:
+        error_msg = ", ".join(error_msgs)
+        if len(error_msg) > 2000:
+            error_msg = error_msg[:1997] + "..."
+        msg = f"{msg} - Original error message: {error_msg}"
+
     raise TabularApiRequestError(msg)
 
 

--- a/helpers/tabular_api_client.py
+++ b/helpers/tabular_api_client.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Any
 
@@ -9,9 +10,88 @@ from helpers.user_agent import USER_AGENT
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
+# User-facing hints (returned to the LLM via tools; keep in English).
+MSG_RESOURCE_NOT_IN_TABULAR = (
+    "This resource ID was not found in the Tabular API. "
+    "Use search_datasets to find a dataset, then list_dataset_resources "
+    "to obtain the correct resource ID."
+)
+
+MSG_TABULAR_SERVER_ISSUE = (
+    "The Tabular API is temporarily unavailable or returned a server error. "
+    "Please try again in about one minute."
+)
+
+MSG_TABULAR_BAD_REQUEST = (
+    "The Tabular API rejected the request (invalid filter, sort column, or parameter). "
+    "Call again without sort or filter to preview rows and confirm column names, "
+    "or align filter_column and sort_column with the resource schema."
+)
+
+MSG_TABULAR_COLUMN_HINT = (
+    "A column or parameter in the request does not exist in this resource; "
+    "remove sort/filter or use exact names from a preview."
+)
+
 
 class ResourceNotAvailableError(Exception):
     """Raised when a resource is not available via the Tabular API."""
+
+
+class TabularApiRequestError(Exception):
+    """Raised when the Tabular API returns a non-success response (other than 404)."""
+
+
+def _optional_column_hint(body: str) -> str | None:
+    try:
+        payload: object = json.loads(body)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    errors = payload.get("errors")
+    if not isinstance(errors, list) or not errors:
+        return None
+    first = errors[0]
+    if not isinstance(first, dict):
+        return None
+    detail = first.get("detail")
+    if isinstance(detail, dict):
+        msg = detail.get("message")
+        if isinstance(msg, str) and "does not exist" in msg.lower():
+            return MSG_TABULAR_COLUMN_HINT
+    return None
+
+
+def _raise_for_tabular_failure(
+    resp: httpx.Response,
+    resource_id: str,
+    *,
+    endpoint: str,
+) -> None:
+    status = resp.status_code
+    body = resp.text
+    logger.warning(
+        "Tabular API: HTTP %s for resource %s (%s endpoint)",
+        status,
+        resource_id,
+        endpoint,
+    )
+    logger.debug("Tabular API response body (truncated): %s", body[:500])
+
+    if status >= 500 or status in (408, 429):
+        raise TabularApiRequestError(MSG_TABULAR_SERVER_ISSUE)
+    if status in (401, 403):
+        raise TabularApiRequestError(
+            f"The Tabular API returned HTTP {status} (access or permission). "
+            "If the problem persists, try again in about one minute."
+        )
+
+    hint = _optional_column_hint(body)
+    msg = MSG_TABULAR_BAD_REQUEST
+    if hint:
+        msg = f"{msg} {hint}"
+    raise TabularApiRequestError(msg)
 
 
 async def _get_session(
@@ -54,18 +134,11 @@ async def fetch_resource_data(
         resp = await sess.get(url, params=query_params, timeout=30.0)
         if resp.status_code == 404:
             logger.warning(f"Tabular API: Resource {resource_id} not found (404)")
-            raise ResourceNotAvailableError(
-                f"Resource {resource_id} not available via Tabular API"
-            )
+            raise ResourceNotAvailableError(MSG_RESOURCE_NOT_IN_TABULAR)
 
         if resp.status_code >= 400:
-            error_body = resp.text
-            logger.error(
-                f"Tabular API: Error {resp.status_code} for resource {resource_id} - "
-                f"Response: {error_body[:500]}"
-            )
+            _raise_for_tabular_failure(resp, resource_id, endpoint="data")
 
-        resp.raise_for_status()
         return resp.json()
     finally:
         if owns_session:
@@ -95,18 +168,11 @@ async def fetch_resource_profile(
             logger.warning(
                 f"Tabular API: Resource profile {resource_id} not found (404)"
             )
-            raise ResourceNotAvailableError(
-                f"Resource {resource_id} profile not available via Tabular API"
-            )
+            raise ResourceNotAvailableError(MSG_RESOURCE_NOT_IN_TABULAR)
 
         if resp.status_code >= 400:
-            error_body = resp.text
-            logger.error(
-                f"Tabular API: Profile error {resp.status_code} for resource {resource_id} - "
-                f"Response: {error_body[:500]}"
-            )
+            _raise_for_tabular_failure(resp, resource_id, endpoint="profile")
 
-        resp.raise_for_status()
         profile_data: dict[str, Any] = resp.json()
 
         # Clean up headers: remove surrounding quotes if present

--- a/helpers/tabular_api_client.py
+++ b/helpers/tabular_api_client.py
@@ -72,12 +72,9 @@ def _raise_for_tabular_failure(
     status = resp.status_code
     body = resp.text
     logger.warning(
-        "Tabular API: HTTP %s for resource %s (%s endpoint)",
-        status,
-        resource_id,
-        endpoint,
+        f"Tabular API: HTTP {status} for resource {resource_id} ({endpoint} endpoint)"
     )
-    logger.debug("Tabular API response body (truncated): %s", body[:500])
+    logger.debug(f"Tabular API response body (truncated): {body[:500]}")
 
     if status >= 500 or status in (408, 429):
         raise TabularApiRequestError(MSG_TABULAR_SERVER_ISSUE)

--- a/helpers/tabular_api_client.py
+++ b/helpers/tabular_api_client.py
@@ -66,7 +66,6 @@ def _optional_column_hint(body: str) -> str | None:
 def _raise_for_tabular_failure(
     resp: httpx.Response,
     resource_id: str,
-    *,
     endpoint: str,
 ) -> None:
     status = resp.status_code

--- a/tests/test_tabular_api.py
+++ b/tests/test_tabular_api.py
@@ -130,8 +130,9 @@ async def test_invalid_resource_raises_error() -> None:
     """Test that invalid resource ID raises ResourceNotAvailableError."""
     invalid_id = "00000000-0000-0000-0000-000000000000"
 
-    with pytest.raises(tabular_api_client.ResourceNotAvailableError):
+    with pytest.raises(tabular_api_client.ResourceNotAvailableError) as exc:
         await tabular_api_client.fetch_resource_data(invalid_id, page_size=1)
+    assert "search_datasets" in str(exc.value)
 
 
 @pytest.mark.asyncio
@@ -139,8 +140,9 @@ async def test_invalid_resource_profile_raises_error() -> None:
     """Test that invalid resource ID raises error for profile."""
     invalid_id = "00000000-0000-0000-0000-000000000000"
 
-    with pytest.raises(tabular_api_client.ResourceNotAvailableError):
+    with pytest.raises(tabular_api_client.ResourceNotAvailableError) as exc:
         await tabular_api_client.fetch_resource_profile(invalid_id)
+    assert "search_datasets" in str(exc.value)
 
 
 @pytest.mark.asyncio

--- a/tests/test_tabular_api_client_errors.py
+++ b/tests/test_tabular_api_client_errors.py
@@ -53,6 +53,31 @@ async def test_fetch_resource_data_400_with_column_detail(
     msg = str(exc.value)
     assert "rejected" in msg.lower()
     assert "does not exist" in msg.lower()
+    assert "original error message" in msg.lower()
+    assert "nombre_piscines" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_fetch_resource_data_400_includes_api_uuid_message(
+    httpx_mock: HTTPXMock,
+) -> None:
+    pattern = re.compile(rf".*/resources/{re.escape(_MOCK_RID)}/data/")
+    payload = {
+        "errors": [
+            {
+                "detail": {
+                    "message": 'invalid input syntax for type uuid: "1234"',
+                },
+            }
+        ]
+    }
+    httpx_mock.add_response(method="GET", url=pattern, status_code=400, json=payload)
+    with pytest.raises(tabular_api_client.TabularApiRequestError) as exc:
+        await tabular_api_client.fetch_resource_data(_MOCK_RID, page_size=1)
+    msg = str(exc.value)
+    assert "rejected" in msg.lower()
+    assert "original error message" in msg.lower()
+    assert "uuid" in msg.lower()
 
 
 @pytest.mark.asyncio

--- a/tests/test_tabular_api_client_errors.py
+++ b/tests/test_tabular_api_client_errors.py
@@ -1,0 +1,74 @@
+"""Unit tests for Tabular API error handling (mocked HTTP, no live API)."""
+
+import re
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from helpers import tabular_api_client
+
+_MOCK_RID = "11111111-1111-1111-1111-111111111111"
+
+
+@pytest.mark.asyncio
+async def test_fetch_resource_data_404_llm_hint(httpx_mock: HTTPXMock) -> None:
+    pattern = re.compile(rf".*/resources/{re.escape(_MOCK_RID)}/data/")
+    httpx_mock.add_response(method="GET", url=pattern, status_code=404)
+    with pytest.raises(tabular_api_client.ResourceNotAvailableError) as exc:
+        await tabular_api_client.fetch_resource_data(_MOCK_RID, page_size=1)
+    msg = str(exc.value)
+    assert "search_datasets" in msg
+    assert "list_dataset_resources" in msg
+
+
+@pytest.mark.asyncio
+async def test_fetch_resource_data_502_server_hint(httpx_mock: HTTPXMock) -> None:
+    pattern = re.compile(rf".*/resources/{re.escape(_MOCK_RID)}/data/")
+    httpx_mock.add_response(method="GET", url=pattern, status_code=502)
+    with pytest.raises(tabular_api_client.TabularApiRequestError) as exc:
+        await tabular_api_client.fetch_resource_data(_MOCK_RID, page_size=1)
+    assert "try again" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_fetch_resource_data_400_with_column_detail(
+    httpx_mock: HTTPXMock,
+) -> None:
+    pattern = re.compile(rf".*/resources/{re.escape(_MOCK_RID)}/data/")
+    payload = {
+        "errors": [
+            {
+                "code": "3e1d503c433b49e78b33165e2c715c5f",
+                "title": "Database error",
+                "detail": {
+                    "code": "42703",
+                    "message": "column x.nombre_piscines does not exist",
+                },
+            }
+        ]
+    }
+    httpx_mock.add_response(method="GET", url=pattern, status_code=400, json=payload)
+    with pytest.raises(tabular_api_client.TabularApiRequestError) as exc:
+        await tabular_api_client.fetch_resource_data(_MOCK_RID, page_size=1)
+    msg = str(exc.value)
+    assert "rejected" in msg.lower()
+    assert "does not exist" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_fetch_resource_data_400_no_http_status_error(
+    httpx_mock: HTTPXMock,
+) -> None:
+    pattern = re.compile(rf".*/resources/{re.escape(_MOCK_RID)}/data/")
+    httpx_mock.add_response(method="GET", url=pattern, status_code=400, text="bad")
+    with pytest.raises(tabular_api_client.TabularApiRequestError):
+        await tabular_api_client.fetch_resource_data(_MOCK_RID, page_size=1)
+
+
+@pytest.mark.asyncio
+async def test_fetch_resource_profile_404_same_hint(httpx_mock: HTTPXMock) -> None:
+    pattern = re.compile(rf".*/resources/{re.escape(_MOCK_RID)}/profile/")
+    httpx_mock.add_response(method="GET", url=pattern, status_code=404)
+    with pytest.raises(tabular_api_client.ResourceNotAvailableError) as exc:
+        await tabular_api_client.fetch_resource_profile(_MOCK_RID)
+    assert "search_datasets" in str(exc.value)

--- a/tools/query_resource_data.py
+++ b/tools/query_resource_data.py
@@ -194,11 +194,14 @@ def register_query_resource_data_tool(mcp: FastMCP) -> None:
             except tabular_api_client.ResourceNotAvailableError as e:
                 logger.warning(f"Resource not available: {resource_id} - {str(e)}")
                 content_parts.append(f"⚠️  {str(e)}")
+            except tabular_api_client.TabularApiRequestError as e:
+                logger.warning(f"Tabular API request failed: {resource_id} - {str(e)}")
+                content_parts.append(f"⚠️  {str(e)}")
             except httpx.HTTPStatusError as e:
                 error_details = f"HTTP {e.response.status_code}: {str(e)}"
                 if e.request:
                     error_details += f" - URL: {e.request.url}"
-                logger.error(
+                logger.warning(
                     f"Tabular API HTTP error for resource {resource_id}: {error_details}"
                 )
                 content_parts.append(f"❌ Tabular API error ({error_details})")


### PR DESCRIPTION
Closes #93.

Sentry was recording two error-level log lines for a single bad Tabular request: one from the API client before `raise_for_status()`, and one from `query_resource_data` after `HTTPStatusError`. Those cases are often predictable (e.g. invalid sort column returning HTTP 400), so they should not be treated like application failures.

This update introduces `TabularApiRequestError` with short, actionable copy for the LLM (404 → `search_datasets` / `list_dataset_resources`; client errors → fix filters/sort; server/transient → retry). Expected Tabular failures are logged at warning, response bodies are truncated at debug, and handled statuses no longer call `raise_for_status()`, which removes the duplicate Sentry event. The fallback `HTTPStatusError` path now logs at warning as well.