### PR TITLE
refactor(query_resource_data): remove question parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ The MCP server provides tools to interact with data.gouv.fr datasets and dataser
 
 - **`query_resource_data`** - Query data from a specific resource via the Tabular API. Fetches rows from a resource to answer questions.
 
-  Parameters: `question` (required), `resource_id` (required), `page` (optional, default: 1), `page_size` (optional, default: 20, max: 200)
+  Parameters: `resource_id` (required), `page` (optional, default: 1), `page_size` (optional, default: 20, max: 200)
 
   Note: Recommended workflow: 1) Use `search_datasets` to find the dataset, 2) Use `list_dataset_resources` to see available resources, 3) Use `query_resource_data` with default `page_size` (20) to preview data structure. For small datasets (<500 rows), increase `page_size` or paginate. For large datasets (>1000 rows), continue paginating or use `get_resource_info` to retrieve the raw file URL and fetch it directly. Works for CSV/XLS resources within Tabular API size limits (CSV ≤ 100 MB, XLSX ≤ 12.5 MB).
 

--- a/tools/query_resource_data.py
+++ b/tools/query_resource_data.py
@@ -13,7 +13,6 @@ def register_query_resource_data_tool(mcp: FastMCP) -> None:
     @mcp.tool()
     @log_tool
     async def query_resource_data(
-        question: str,
         resource_id: str,
         page: int = 1,
         page_size: int = 20,
@@ -83,12 +82,7 @@ def register_query_resource_data_tool(mcp: FastMCP) -> None:
             ]
             if dataset_id:
                 content_parts.append(f"Dataset: {dataset_title} (ID: {dataset_id})")
-            content_parts.extend(
-                [
-                    f"Question: {question}",
-                    "",
-                ]
-            )
+            content_parts.append("")
 
             # Show applied filters if any
             if filter_column and filter_value is not None:


### PR DESCRIPTION
The `question` argument was only echoed in the tool output and duplicated chat context. Removing it trims tokens on each call and in responses.