### PR TITLE
refactor(datagouv): simplify tags handling to match API swagger

### DIFF
--- a/helpers/datagouv_api_client.py
+++ b/helpers/datagouv_api_client.py
@@ -245,12 +245,7 @@ async def search_dataservices(
         dataservices: list[dict[str, Any]] = data.get("data", [])
         results: list[dict[str, Any]] = []
         for ds in dataservices:
-            tags: list[str] = []
-            for tag in ds.get("tags", []):
-                if isinstance(tag, str):
-                    tags.append(tag)
-                elif isinstance(tag, dict):
-                    tags.append(tag.get("name", ""))
+            tags: list[str] = ds.get("tags") or []
 
             results.append(
                 {
@@ -316,13 +311,7 @@ async def search_datasets(
         # Extract relevant fields for each dataset
         results: list[dict[str, Any]] = []
         for ds in datasets:
-            # Handle tags - can be strings or objects with "name" field
-            tags: list[str] = []
-            for tag in ds.get("tags", []):
-                if isinstance(tag, str):
-                    tags.append(tag)
-                elif isinstance(tag, dict):
-                    tags.append(tag.get("name", ""))
+            tags: list[str] = ds.get("tags") or []
 
             results.append(
                 {

--- a/tools/get_dataservice_info.py
+++ b/tools/get_dataservice_info.py
@@ -56,15 +56,7 @@ def register_get_dataservice_info_tool(mcp: FastMCP) -> None:
                     if org.get("id"):
                         content_parts.append(f"  Organization ID: {org.get('id')}")
 
-            # Tags
-            tags = []
-            for tag in data.get("tags", []):
-                if isinstance(tag, str):
-                    tags.append(tag)
-                elif isinstance(tag, dict):
-                    tag_name = tag.get("name", "")
-                    if tag_name:
-                        tags.append(tag_name)
+            tags: list[str] = data.get("tags") or []
             if tags:
                 content_parts.append("")
                 content_parts.append(f"Tags: {', '.join(tags[:10])}")

--- a/tools/get_dataset_info.py
+++ b/tools/get_dataset_info.py
@@ -47,15 +47,7 @@ def register_get_dataset_info_tool(mcp: FastMCP) -> None:
                     if org.get("id"):
                         content_parts.append(f"  Organization ID: {org.get('id')}")
 
-            # Handle tags
-            tags = []
-            for tag in data.get("tags", []):
-                if isinstance(tag, str):
-                    tags.append(tag)
-                elif isinstance(tag, dict):
-                    tag_name = tag.get("name", "")
-                    if tag_name:
-                        tags.append(tag_name)
+            tags: list[str] = data.get("tags") or []
             if tags:
                 content_parts.append("")
                 content_parts.append(f"Tags: {', '.join(tags[:10])}")


### PR DESCRIPTION
The old tag handling assumed multiple shapes (strings vs objects with `name`, then extra guards), while both API versions document `tags` on Dataset and Dataservice resources as an array of strings, so we only need to treat missing or null as an empty list.

References:
- https://www.data.gouv.fr/api/1/swagger.json
- https://www.data.gouv.fr/api/2/swagger.json

Replaces https://github.com/datagouv/datagouv-mcp/pull/54