### PR TITLE
feat: add deep health check and call_tool dev script

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ The MCP server is built using the [official Python SDK for MCP servers and clien
 
 **Streamable HTTP transport (standards-compliant):**
 - `POST /mcp` - JSON-RPC messages (client → server)
-- `GET /health` - Simple JSON health probe (`{"status":"ok","timestamp":"..."}`)
+- `GET /health` - Deep health probe: runs a full MCP handshake and tool call. Returns `{"status":"ok",...}` with HTTP 200 if healthy, or `{"status":"mcp_unavailable"}` with HTTP 503 if the MCP stack is not responding correctly.
 
 ## 🛠️ Available Tools
 
@@ -441,6 +441,25 @@ uv run pytest -m stress
 ```
 
 Currently includes a test that mixes normal requests with abrupt client TCP disconnects, verifying the server stays healthy and keeps serving despite the disruption. It uses `MCP_PORT` (default: `8000`) to connect to the local server.
+
+### 🩺 Deep Health Check
+
+Runs a full MCP handshake and calls `search_datasets` to validate end-to-end stack health. Requires a running server and is excluded from default `pytest` runs.
+
+```shell
+# Start the server first, then in another terminal:
+uv run pytest -m deep_health
+```
+
+### 🛠️ Local Tool Testing Script
+
+`scripts/call_tool.py` lets you call any MCP tool directly without manually managing the curl handshake. Requires a running server.
+
+```shell
+# Start the server first, then in another terminal:
+python scripts/call_tool.py search_datasets '{"query": "IRVE"}'
+python scripts/call_tool.py get_resource_info '{"resource_id": "<id>"}'
+```
 
 ### 🔍 Interactive Testing with MCP Inspector
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ The MCP server is built using the [official Python SDK for MCP servers and clien
 
 **Streamable HTTP transport (standards-compliant):**
 - `POST /mcp` - JSON-RPC messages (client → server)
-- `GET /health` - Deep health probe: runs a full MCP handshake and tool call. Returns `{"status":"ok",...}` with HTTP 200 if healthy, or `{"status":"mcp_unavailable"}` with HTTP 503 if the MCP stack is not responding correctly.
+- `GET /health` - Health check endpoint: runs a full MCP handshake and tool call. Returns `{"status":"ok",...}` with HTTP 200 if healthy, or `{"status":"mcp_unavailable"}` with HTTP 503 if the MCP stack is not responding correctly.
 
 ## 🛠️ Available Tools
 
@@ -442,13 +442,13 @@ uv run pytest -m stress
 
 Currently includes a test that mixes normal requests with abrupt client TCP disconnects, verifying the server stays healthy and keeps serving despite the disruption. It uses `MCP_PORT` (default: `8000`) to connect to the local server.
 
-### 🩺 Deep Health Check
+### 🩺 Run a Health Check from the CLI
 
 Runs a full MCP handshake and calls `search_datasets` to validate end-to-end stack health. Requires a running server and is excluded from default `pytest` runs.
 
 ```shell
 # Start the server first, then in another terminal:
-uv run pytest -m deep_health
+uv run pytest -m health_check
 ```
 
 ### 🛠️ Local Tool Testing Script

--- a/helpers/health_probe.py
+++ b/helpers/health_probe.py
@@ -1,0 +1,51 @@
+"""
+Health probe that runs a deep check on the MCP itself (doing a full handshake)
+and calls the `search_datasets` tool with page_size=1 for a full round-trip validation.
+
+Checks if the call response actually contains `data` for valid MCP response
+
+returns True if OK
+        False if round-trip failed (meaning the probe failed)
+"""
+
+import logging
+import os
+
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from mcp.types import TextContent
+
+from helpers.logging import MAIN_LOGGER_NAME
+
+logger = logging.getLogger(MAIN_LOGGER_NAME)
+
+
+async def _run_deep_check() -> bool:
+    logger.debug("health probe: starting deep check")
+    try:
+        port = os.getenv("MCP_PORT", "8000")
+        url = f"http://localhost:{port}/mcp"
+
+        async with streamable_http_client(url) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                result = await session.call_tool(
+                    "search_datasets", {"query": "transport", "page_size": 1}
+                )
+                # result.content is a list of content blocks from the tool response
+                # search_datasets always returns a TextContent block
+                # we check it's non-empty to confirm a valid round-trip
+                if not result.content or not isinstance(result.content[0], TextContent):
+                    logger.error(
+                        "health probe: unexpected response from search_datasets"
+                    )
+                    return False
+                if not result.content[0].text:
+                    logger.error("health probe: empty response from search_datasets")
+                    return False
+
+        return True
+
+    except Exception as e:
+        logger.error("health probe: deep check failed: %s", e)
+        return False

--- a/helpers/health_probe.py
+++ b/helpers/health_probe.py
@@ -1,5 +1,5 @@
 """
-Health probe that runs a deep check on the MCP itself (doing a full handshake)
+Health probe that runs a check on the MCP itself (doing a full handshake)
 and calls the `search_datasets` tool with page_size=1 for a full round-trip validation.
 
 Checks if the call response actually contains `data` for valid MCP response
@@ -9,43 +9,33 @@ returns True if OK
 """
 
 import logging
-import os
 
-from mcp.client.session import ClientSession
-from mcp.client.streamable_http import streamable_http_client
 from mcp.types import TextContent
 
 from helpers.logging import MAIN_LOGGER_NAME
+from helpers.mcp_client import call_tool_on_mcp
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
 
-async def _run_deep_check() -> bool:
-    logger.debug("health probe: starting deep check")
+async def _run_health_check() -> bool:
+    logger.debug("health probe: starting health check")
     try:
-        port = os.getenv("MCP_PORT", "8000")
-        url = f"http://localhost:{port}/mcp"
-
-        async with streamable_http_client(url) as (read, write, _):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                result = await session.call_tool(
-                    "search_datasets", {"query": "transport", "page_size": 1}
-                )
-                # result.content is a list of content blocks from the tool response
-                # search_datasets always returns a TextContent block
-                # we check it's non-empty to confirm a valid round-trip
-                if not result.content or not isinstance(result.content[0], TextContent):
-                    logger.error(
-                        "health probe: unexpected response from search_datasets"
-                    )
-                    return False
-                if not result.content[0].text:
-                    logger.error("health probe: empty response from search_datasets")
-                    return False
+        result = await call_tool_on_mcp(
+            "search_datasets", {"query": "transport", "page_size": 1}
+        )
+        # result.content is a list of content blocks from the tool response
+        # search_datasets always returns a TextContent block
+        # we check it's non-empty to confirm a valid round-trip
+        if not result.content or not isinstance(result.content[0], TextContent):
+            logger.error("health probe: unexpected response from search_datasets")
+            return False
+        if not result.content[0].text:
+            logger.error("health probe: empty response from search_datasets")
+            return False
 
         return True
 
     except Exception as e:
-        logger.error("health probe: deep check failed: %s", e)
+        logger.error(f"health probe check failed: {e}")
         return False

--- a/helpers/mcp_client.py
+++ b/helpers/mcp_client.py
@@ -1,0 +1,21 @@
+"""
+Common helper to invoke an MCP tool call with the given params.
+"""
+
+import os
+
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from mcp.types import CallToolResult
+
+
+async def call_tool_on_mcp(tool_name: str, params: dict) -> CallToolResult:
+    port = os.getenv("MCP_PORT", "8000")
+    url = f"http://localhost:{port}/mcp"
+
+    async with streamable_http_client(url) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool(tool_name, params)
+
+    return result

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import uvicorn
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
-from helpers.health_probe import _run_deep_check
+from helpers.health_probe import _run_health_check
 from helpers.logging import MAIN_LOGGER_NAME, UVICORN_LOGGING_CONFIG
 from helpers.matomo import (
     apply_matomo_request_context,
@@ -75,7 +75,7 @@ def with_monitoring(
                 except PackageNotFoundError:
                     app_version = "unknown"
 
-                is_healthy = await _run_deep_check()
+                is_healthy = await _run_health_check()
                 if is_healthy:
                     body = json.dumps(
                         {

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ import uvicorn
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
+from helpers.health_probe import _run_deep_check
 from helpers.logging import MAIN_LOGGER_NAME, UVICORN_LOGGING_CONFIG
 from helpers.matomo import (
     apply_matomo_request_context,
@@ -74,21 +75,32 @@ def with_monitoring(
                 except PackageNotFoundError:
                     app_version = "unknown"
 
-                body = json.dumps(
-                    {
-                        "status": "ok",
-                        "uptime_since": SERVER_START_TIME.isoformat(),
-                        "version": app_version,
-                        "env": os.getenv("MCP_ENV", "unknown"),
-                        "data_env": os.getenv("DATAGOUV_API_ENV", "unknown"),
-                    }
-                ).encode("utf-8")
+                is_healthy = await _run_deep_check()
+                if is_healthy:
+                    body = json.dumps(
+                        {
+                            "status": "ok",
+                            "uptime_since": SERVER_START_TIME.isoformat(),
+                            "version": app_version,
+                            "env": os.getenv("MCP_ENV", "unknown"),
+                            "data_env": os.getenv("DATAGOUV_API_ENV", "unknown"),
+                        }
+                    ).encode("utf-8")
+                    http_status = 200
+                else:
+                    body = json.dumps({"status": "mcp_unavailable"}).encode("utf-8")
+                    http_status = 503
+
                 headers = [
                     (b"content-type", b"application/json"),
                     (b"content-length", str(len(body)).encode("utf-8")),
                 ]
                 await send(
-                    {"type": "http.response.start", "status": 200, "headers": headers}
+                    {
+                        "type": "http.response.start",
+                        "status": http_status,
+                        "headers": headers,
+                    }
                 )
                 await send({"type": "http.response.body", "body": body})
                 return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,6 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 markers = [
     "stress: stress tests requiring a running MCP server (not run by default)",
-    "deep_health: deep health check requiring a running MCP server (not run by default)",
+    "health_check: health check requiring a running MCP server (not run by default)",
 ]
-addopts = "-m 'not stress and not deep_health'"
+addopts = "-m 'not stress and not health_check'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,8 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-markers = ["stress: stress tests requiring a running MCP server (not run by default)"]
-addopts = "-m 'not stress'"
+markers = [
+    "stress: stress tests requiring a running MCP server (not run by default)",
+    "deep_health: deep health check requiring a running MCP server (not run by default)",
+]
+addopts = "-m 'not stress and not deep_health'"

--- a/scripts/call_tool.py
+++ b/scripts/call_tool.py
@@ -1,0 +1,56 @@
+"""
+CLI helper to call any MCP tool without manual curl handshaking.
+
+Usage:
+    python scripts/call_tool.py <tool_name> '<json_args>'
+
+Example:
+    python scripts/call_tool.py search_datasets '{"query": "IRVE"}'
+    python scripts/call_tool.py get_resource_info '{"resource_id": "abc123"}'
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sys
+
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from mcp.types import TextContent
+
+from helpers.logging import MAIN_LOGGER_NAME
+
+logger = logging.getLogger(MAIN_LOGGER_NAME)
+
+
+async def call_tool(tool_name: str, args: dict) -> None:
+    """
+    Connect to MCP server and call a tool with given arguments.
+    """
+    logger.debug("Initiating tool call: %s", tool_name)
+    port = os.getenv("MCP_PORT", "8000")
+    url = f"http://localhost:{port}/mcp"
+
+    async with streamable_http_client(url) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool(tool_name, args)
+            if result.content and isinstance(result.content[0], TextContent):
+                print(result.content[0].text)
+            elif not result.content:
+                print(f"Error: empty response from tool '{tool_name}'", file=sys.stderr)
+            else:
+                print(
+                    f"Error: unexpected content type from tool '{tool_name}': {type(result.content[0]).__name__}",
+                    file=sys.stderr,
+                )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python scripts/call_tool.py <tool_name> '<json_args>'")
+        sys.exit(1)
+    tool = sys.argv[1]
+    arguments = json.loads(sys.argv[2]) if len(sys.argv) > 2 else {}
+    asyncio.run(call_tool(tool, arguments))

--- a/scripts/call_tool.py
+++ b/scripts/call_tool.py
@@ -12,14 +12,12 @@ Example:
 import asyncio
 import json
 import logging
-import os
 import sys
 
-from mcp.client.session import ClientSession
-from mcp.client.streamable_http import streamable_http_client
 from mcp.types import TextContent
 
 from helpers.logging import MAIN_LOGGER_NAME
+from helpers.mcp_client import call_tool_on_mcp
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
@@ -28,23 +26,19 @@ async def call_tool(tool_name: str, args: dict) -> None:
     """
     Connect to MCP server and call a tool with given arguments.
     """
-    logger.debug("Initiating tool call: %s", tool_name)
-    port = os.getenv("MCP_PORT", "8000")
-    url = f"http://localhost:{port}/mcp"
+    logger.debug(f"Initiating tool call: {tool_name}")
 
-    async with streamable_http_client(url) as (read, write, _):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
-            result = await session.call_tool(tool_name, args)
-            if result.content and isinstance(result.content[0], TextContent):
-                print(result.content[0].text)
-            elif not result.content:
-                print(f"Error: empty response from tool '{tool_name}'", file=sys.stderr)
-            else:
-                print(
-                    f"Error: unexpected content type from tool '{tool_name}': {type(result.content[0]).__name__}",
-                    file=sys.stderr,
-                )
+    result = await call_tool_on_mcp(tool_name, args)
+
+    if result.content and isinstance(result.content[0], TextContent):
+        print(result.content[0].text)
+    elif not result.content:
+        print(f"Error: empty response from tool '{tool_name}'", file=sys.stderr)
+    else:
+        print(
+            f"Error: unexpected content type from tool '{tool_name}': {type(result.content[0]).__name__}",
+            file=sys.stderr,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_deep_health.py
+++ b/tests/test_deep_health.py
@@ -1,0 +1,25 @@
+"""
+Deep health check: full MCP handshake + search_datasets tool call.
+
+Requires a running MCP server (not started by the test).
+Excluded from normal pytest runs -- launch explicitly with:
+
+    uv run pytest -m deep_health
+"""
+
+import pytest
+
+from helpers.health_probe import _run_deep_check
+
+pytestmark = pytest.mark.deep_health
+
+
+async def test_deep_health():
+    """
+    Runs the full MCP handshake and calls search_datasets with page_size=1.
+    Asserts a valid non-empty response to confirm end-to-end stack is healthy.
+    """
+    is_healthy = await _run_deep_check()
+    assert is_healthy, (
+        "Deep health check failed: MCP handshake or tool call returned unexpected result"
+    )

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,25 +1,25 @@
 """
-Deep health check: full MCP handshake + search_datasets tool call.
+Health check: full MCP handshake + search_datasets tool call.
 
 Requires a running MCP server (not started by the test).
 Excluded from normal pytest runs -- launch explicitly with:
 
-    uv run pytest -m deep_health
+    uv run pytest -m health_check
 """
 
 import pytest
 
-from helpers.health_probe import _run_deep_check
+from helpers.health_probe import _run_health_check
 
-pytestmark = pytest.mark.deep_health
+pytestmark = pytest.mark.health_check
 
 
-async def test_deep_health():
+async def test_health_check():
     """
     Runs the full MCP handshake and calls search_datasets with page_size=1.
     Asserts a valid non-empty response to confirm end-to-end stack is healthy.
     """
-    is_healthy = await _run_deep_check()
+    is_healthy = await _run_health_check()
     assert is_healthy, (
-        "Deep health check failed: MCP handshake or tool call returned unexpected result"
+        "Health check failed: MCP handshake or tool call returned unexpected result"
     )

--- a/tests/test_health_endpoint.py
+++ b/tests/test_health_endpoint.py
@@ -5,16 +5,20 @@ from main import asgi_app
 
 
 @pytest.mark.asyncio
-async def test_health_endpoint_returns_ok_status():
+async def test_health_endpoint_returns_valid_response():
     transport = ASGITransport(app=asgi_app)
     async with AsyncClient(transport=transport, base_url="http://testserver") as client:
         response = await client.get("/health")
 
-    assert response.status_code == 200
+    assert response.status_code in (200, 503)
     payload = response.json()
-    assert payload.get("status") == "ok"
-    assert "uptime_since" in payload
-    assert "version" in payload
-    assert isinstance(payload.get("version"), str)
-    assert "env" in payload
-    assert "data_env" in payload
+    assert "status" in payload
+    if response.status_code == 200:
+        assert payload["status"] == "ok"
+        assert "uptime_since" in payload
+        assert "version" in payload
+        assert isinstance(payload.get("version"), str)
+        assert "env" in payload
+        assert "data_env" in payload
+    else:
+        assert payload["status"] == "mcp_unavailable"


### PR DESCRIPTION
- helpers/health_probe.py: `_run_deep_check()` runs full MCP handshake and calls `search_datasets(page_size=1)` to validate end-to-end stack
- main.py: `/health` now returns `503` if probe fails, `200` if healthy
- tests/test_deep_health.py: `@pytest.mark.deep_health`, excluded from CI, run manually with
 `uv run pytest -m deep_health`
- tests/test_health_endpoint.py: updated to accept `200` or `503`
- scripts/call_tool.py: CLI helper, no more manual curl handshaking
- pyproject.toml: `deep_health` marker registered and excluded from CI
- README.md: updated `/health` docs and added sections for `deep_health` test and `scripts/call_tool.py`


## Test plan

67/67 tests pass (including 3 new from upstream rebase)

<img width="1153" height="366" alt="image" src="https://github.com/user-attachments/assets/46db5ef0-9dd9-416e-a728-2656e27eaa31" />

`ruff check` and `ruff format` pass

<img width="447" height="98" alt="image" src="https://github.com/user-attachments/assets/7b9f28ca-4594-4a8e-a8e2-8ff42c4a3930" />


`uv run pytest -m deep_health` passes against a running local server

<img width="1151" height="261" alt="image" src="https://github.com/user-attachments/assets/f7bdf623-59ce-4162-a15d-aacfcc520df9" />

Closes #22