### PR TITLE
feat(matomo): track MCP tool calls as Matomo events

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       - MATOMO_URL=${MATOMO_URL}
       - MATOMO_SITE_ID=${MATOMO_SITE_ID}
       - MATOMO_AUTH_TOKEN=${MATOMO_AUTH_TOKEN}
-      - MATOMO_AUTH=${MATOMO_AUTH}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python", "-c", "import os, urllib.request; port = os.getenv('MCP_PORT', '8000'); urllib.request.urlopen(f'http://localhost:{port}/health')"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - MATOMO_URL=${MATOMO_URL}
       - MATOMO_SITE_ID=${MATOMO_SITE_ID}
       - MATOMO_AUTH_TOKEN=${MATOMO_AUTH_TOKEN}
+      - MATOMO_AUTH=${MATOMO_AUTH}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python", "-c", "import os, urllib.request; port = os.getenv('MCP_PORT', '8000'); urllib.request.urlopen(f'http://localhost:{port}/health')"]

--- a/helpers/logging.py
+++ b/helpers/logging.py
@@ -1,3 +1,4 @@
+import asyncio
 import functools
 import inspect
 import logging
@@ -40,6 +41,9 @@ logger = logging.getLogger(TOOLS_LOGGER_NAME)
 def log_tool(func):
     @functools.wraps(func)
     async def async_wrapper(*args, **kwargs):
+        from helpers.matomo import track_matomo_tool
+
+        asyncio.create_task(track_matomo_tool(func.__name__))
         logger.info("Tool called: %s | kwargs=%s", func.__name__, kwargs)
         return await func(*args, **kwargs)
 

--- a/helpers/matomo.py
+++ b/helpers/matomo.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from contextvars import ContextVar, Token
 from datetime import UTC, datetime
 
 import httpx
@@ -10,25 +11,54 @@ from helpers.logging import MAIN_LOGGER_NAME
 MATOMO_URL = os.getenv("MATOMO_URL")
 MATOMO_SITE_ID = os.getenv("MATOMO_SITE_ID")
 MATOMO_AUTH_TOKEN = os.getenv("MATOMO_AUTH_TOKEN")
+MATOMO_TOOL_EVENT_CATEGORY = "MCP"
+
+_request_page_url: ContextVar[str] = ContextVar(
+    "matomo_request_page_url", default="https://localhost/mcp"
+)
+_request_user_agent: ContextVar[str] = ContextVar(
+    "matomo_request_user_agent", default=""
+)
 
 # Shared client reused across all tracking calls to avoid creating a new
 # TCP connection + SSL handshake + httpx overhead on every MCP request.
 _client = httpx.AsyncClient(timeout=1.5)
 
 
-async def track_matomo(url: str, path: str, headers: dict[str, str]) -> None:
-    """
-    Sends an asynchronous tracking request to Matomo.
-    Fired in the background to avoid blocking the MCP server response.
-    Skipped when MATOMO_URL or MATOMO_SITE_ID is unset.
-    """
+def apply_matomo_request_context(
+    headers: dict[str, str], path: str
+) -> tuple[Token[str], Token[str]]:
+    """Bind URL and User-Agent for the current HTTP request (for tool event tracking)."""
+    host = headers.get("host", "localhost")
+    full_url = f"https://{host}{path}"
+    return (
+        _request_page_url.set(full_url),
+        _request_user_agent.set(headers.get("user-agent", "")),
+    )
+
+
+def reset_matomo_request_context(
+    url_token: Token[str],
+    ua_token: Token[str],
+) -> None:
+    _request_page_url.reset(url_token)
+    _request_user_agent.reset(ua_token)
+
+
+async def _post_matomo(payload: dict) -> None:
+    """POST tracking payload to Matomo; no-op when tracking is disabled."""
     if not MATOMO_URL or not MATOMO_SITE_ID:
         return
+    try:
+        await _client.post(f"{MATOMO_URL}/matomo.php", data=payload)
+    except Exception as e:
+        logging.getLogger(MAIN_LOGGER_NAME).error(f"Matomo tracking failed: {e}")
 
-    # Extract user-agent for better Matomo analytics
-    user_agent: str = headers.get("user-agent", "")
 
-    payload: dict = {
+async def track_matomo_request(url: str, path: str, headers: dict[str, str]) -> None:
+    """Track one HTTP-level MCP request (page-action style)."""
+    user_agent = headers.get("user-agent", "")
+    payload = {
         "idsite": MATOMO_SITE_ID,
         "rec": 1,
         "url": url,
@@ -37,9 +67,23 @@ async def track_matomo(url: str, path: str, headers: dict[str, str]) -> None:
         "ua": user_agent,
         "rand": datetime.now(UTC).timestamp(),
     }
+    await _post_matomo(payload)
 
-    try:
-        await _client.post(f"{MATOMO_URL}/matomo.php", data=payload)
-    except Exception as e:
-        # Fail silently to ensure the MCP server remains operational
-        logging.getLogger(MAIN_LOGGER_NAME).error(f"Matomo tracking failed: {e}")
+
+async def track_matomo_tool(tool_name: str) -> None:
+    """
+    Track an MCP tool invocation as a Matomo event (Behavior > Events).
+    Uses e_c / e_a and ca=1 per the HTTP Tracking API.
+    """
+    payload = {
+        "idsite": MATOMO_SITE_ID,
+        "rec": 1,
+        "url": _request_page_url.get(),
+        "ca": 1,
+        "e_c": MATOMO_TOOL_EVENT_CATEGORY,
+        "e_a": tool_name,
+        "token_auth": MATOMO_AUTH_TOKEN,
+        "ua": _request_user_agent.get(),
+        "rand": datetime.now(UTC).timestamp(),
+    }
+    await _post_matomo(payload)

--- a/main.py
+++ b/main.py
@@ -12,7 +12,11 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
 from helpers.logging import MAIN_LOGGER_NAME, UVICORN_LOGGING_CONFIG
-from helpers.matomo import track_matomo
+from helpers.matomo import (
+    apply_matomo_request_context,
+    reset_matomo_request_context,
+    track_matomo_request,
+)
 from helpers.sentry import init_sentry
 from tools import register_tools
 
@@ -89,24 +93,24 @@ def with_monitoring(
                 await send({"type": "http.response.body", "body": body})
                 return
 
-            # Matomo Tracking for /mcp requests
-            # Convert ASGI headers list to a dictionary for the helper
+            # Matomo: bind request URL/UA for tool event tracking; HTTP-level hit in background
             headers_dict: dict[str, str] = {
                 k.decode("utf-8"): v.decode("utf-8")
                 for k, v in scope.get("headers", [])
             }
-
-            # Construct the full URL
+            url_token, ua_token = apply_matomo_request_context(headers_dict, path)
             host: str = headers_dict.get("host", "localhost")
             full_url: str = f"https://{host}{path}"
+            try:
+                asyncio.create_task(
+                    track_matomo_request(url=full_url, path=path, headers=headers_dict)
+                )
+                await inner_app(scope, receive, send)
+            finally:
+                reset_matomo_request_context(url_token, ua_token)
+            return
 
-            # Fire the tracking task in the background
-            # Since path is always /mcp, the helper will log "MCP Request: /mcp"
-            asyncio.create_task(
-                track_matomo(url=full_url, path=path, headers=headers_dict)
-            )
-
-        # Continue the MCP server logic
+        # Continue the MCP server logic (non-HTTP scopes, e.g. lifespan)
         await inner_app(scope, receive, send)
 
     return app

--- a/tests/test_matomo.py
+++ b/tests/test_matomo.py
@@ -1,0 +1,78 @@
+"""Tests for Matomo tracking helpers."""
+
+from urllib.parse import parse_qs
+
+import pytest
+
+import helpers.matomo as matomo
+
+
+@pytest.mark.asyncio
+async def test_track_matomo_request_sends_expected_form_fields(
+    httpx_mock,
+    monkeypatch,
+):
+    monkeypatch.setattr(matomo, "MATOMO_URL", "https://matomo.example")
+    monkeypatch.setattr(matomo, "MATOMO_SITE_ID", "7")
+    monkeypatch.setattr(matomo, "MATOMO_AUTH_TOKEN", "tok")
+    httpx_mock.add_response()
+
+    await matomo.track_matomo_request(
+        "https://mcp.example/mcp",
+        "/mcp",
+        {"user-agent": "MCPTest/1"},
+    )
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 1
+    assert str(requests[0].url) == "https://matomo.example/matomo.php"
+    body = requests[0].content.decode()
+    params = parse_qs(body, strict_parsing=True)
+    assert params["idsite"] == ["7"]
+    assert params["rec"] == ["1"]
+    assert params["url"] == ["https://mcp.example/mcp"]
+    assert params["action_name"] == ["MCP Request: /mcp"]
+    assert params["ua"] == ["MCPTest/1"]
+    assert params["token_auth"] == ["tok"]
+    assert "e_c" not in params
+    assert "ca" not in params
+
+
+@pytest.mark.asyncio
+async def test_track_matomo_tool_sends_event_fields(httpx_mock, monkeypatch):
+    monkeypatch.setattr(matomo, "MATOMO_URL", "https://matomo.example")
+    monkeypatch.setattr(matomo, "MATOMO_SITE_ID", "7")
+    monkeypatch.setattr(matomo, "MATOMO_AUTH_TOKEN", None)  # omitted from POST body
+    url_tok, ua_tok = matomo.apply_matomo_request_context(
+        {"user-agent": "ToolUA/2", "host": "mcp.example"},
+        "/mcp",
+    )
+    httpx_mock.add_response()
+    try:
+        await matomo.track_matomo_tool("search_datasets")
+    finally:
+        matomo.reset_matomo_request_context(url_tok, ua_tok)
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 1
+    body = requests[0].content.decode()
+    params = parse_qs(body, strict_parsing=True)
+    assert params["idsite"] == ["7"]
+    assert params["e_c"] == ["MCP"]
+    assert params["e_a"] == ["search_datasets"]
+    assert params["ca"] == ["1"]
+    assert params["url"] == ["https://mcp.example/mcp"]
+    assert params["ua"] == ["ToolUA/2"]
+    assert "token_auth" not in params
+
+
+@pytest.mark.asyncio
+async def test_post_matomo_skips_when_not_configured(httpx_mock, monkeypatch):
+    monkeypatch.setattr(matomo, "MATOMO_URL", "")
+    monkeypatch.setattr(matomo, "MATOMO_SITE_ID", "1")
+    await matomo.track_matomo_request(
+        "https://x/y",
+        "/y",
+        {},
+    )
+    assert len(httpx_mock.get_requests()) == 0

--- a/tests/test_tool_logging.py
+++ b/tests/test_tool_logging.py
@@ -46,7 +46,8 @@ async def test_tool_logs_kwargs(
     call_args: dict,
     expected_kwargs: dict,
 ):
-    httpx_mock.add_response(json={})
+    httpx_mock.add_response(json={})  # Mock tool call
+    httpx_mock.add_response(json={})  # Mock Matomo call
     with caplog.at_level(logging.INFO, logger=TOOLS_LOGGER_NAME):
         await mcp.call_tool(tool_name, call_args)
 

--- a/tests/test_tool_logging.py
+++ b/tests/test_tool_logging.py
@@ -42,10 +42,13 @@ async def test_tool_logs_kwargs(
     mcp: FastMCP,
     caplog,
     httpx_mock: HTTPXMock,
+    monkeypatch,
     tool_name: str,
     call_args: dict,
     expected_kwargs: dict,
 ):
+    monkeypatch.setattr("helpers.matomo.MATOMO_URL", "https://matomo.example.com")
+    monkeypatch.setattr("helpers.matomo.MATOMO_SITE_ID", "1")
     httpx_mock.add_response(json={})  # Mock tool call
     httpx_mock.add_response(json={})  # Mock Matomo call
     with caplog.at_level(logging.INFO, logger=TOOLS_LOGGER_NAME):


### PR DESCRIPTION
HTTP-level Matomo hits did not show which MCP tools clients actually call, which limits product analytics.

This adds per-tool Matomo events (category/action) alongside the existing per-request tracking, reuses a single posting helper, propagates request URL and User-Agent for tool hits.
