### PR TITLE
feat: add tool titles and MCP annotations

### DIFF
--- a/helpers/mcp_tool_defaults.py
+++ b/helpers/mcp_tool_defaults.py
@@ -1,0 +1,9 @@
+from mcp.types import ToolAnnotations
+
+# All tools query public data.gouv.fr and related services; retries do not mutate remote state.
+READ_ONLY_EXTERNAL_API_TOOL = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=True,
+)

--- a/tools/get_dataservice_info.py
+++ b/tools/get_dataservice_info.py
@@ -5,10 +5,14 @@ from mcp.server.fastmcp import FastMCP
 
 from helpers import datagouv_api_client, env_config
 from helpers.logging import log_tool
+from helpers.mcp_tool_defaults import READ_ONLY_EXTERNAL_API_TOOL
 
 
 def register_get_dataservice_info_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(
+        title="Get dataservice info",
+        annotations=READ_ONLY_EXTERNAL_API_TOOL,
+    )
     @log_tool
     async def get_dataservice_info(dataservice_id: str) -> str:
         """

--- a/tools/get_dataservice_openapi_spec.py
+++ b/tools/get_dataservice_openapi_spec.py
@@ -6,6 +6,7 @@ from mcp.server.fastmcp import FastMCP
 
 from helpers import datagouv_api_client
 from helpers.logging import MAIN_LOGGER_NAME, log_tool
+from helpers.mcp_tool_defaults import READ_ONLY_EXTERNAL_API_TOOL
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
@@ -85,7 +86,10 @@ def _summarize_spec(spec: dict[str, Any]) -> str:
 
 
 def register_get_dataservice_openapi_spec_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(
+        title="Get dataservice OpenAPI spec",
+        annotations=READ_ONLY_EXTERNAL_API_TOOL,
+    )
     @log_tool
     async def get_dataservice_openapi_spec(dataservice_id: str) -> str:
         """

--- a/tools/get_dataset_info.py
+++ b/tools/get_dataset_info.py
@@ -3,10 +3,14 @@ from mcp.server.fastmcp import FastMCP
 
 from helpers import datagouv_api_client, env_config
 from helpers.logging import log_tool
+from helpers.mcp_tool_defaults import READ_ONLY_EXTERNAL_API_TOOL
 
 
 def register_get_dataset_info_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(
+        title="Get dataset info",
+        annotations=READ_ONLY_EXTERNAL_API_TOOL,
+    )
     @log_tool
     async def get_dataset_info(dataset_id: str) -> str:
         """

--- a/tools/get_metrics.py
+++ b/tools/get_metrics.py
@@ -5,12 +5,16 @@ from mcp.server.fastmcp import FastMCP
 
 from helpers import datagouv_api_client, metrics_api_client
 from helpers.logging import MAIN_LOGGER_NAME, log_tool
+from helpers.mcp_tool_defaults import READ_ONLY_EXTERNAL_API_TOOL
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
 
 def register_get_metrics_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(
+        title="Get usage metrics",
+        annotations=READ_ONLY_EXTERNAL_API_TOOL,
+    )
     @log_tool
     async def get_metrics(
         dataset_id: str | None = None,

--- a/tools/get_resource_info.py
+++ b/tools/get_resource_info.py
@@ -3,10 +3,14 @@ from mcp.server.fastmcp import FastMCP
 
 from helpers import crawler_api_client, datagouv_api_client, env_config
 from helpers.logging import log_tool
+from helpers.mcp_tool_defaults import READ_ONLY_EXTERNAL_API_TOOL
 
 
 def register_get_resource_info_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(
+        title="Get resource info",
+        annotations=READ_ONLY_EXTERNAL_API_TOOL,
+    )
     @log_tool
     async def get_resource_info(resource_id: str) -> str:
         """

--- a/tools/list_dataset_resources.py
+++ b/tools/list_dataset_resources.py
@@ -2,10 +2,14 @@ from mcp.server.fastmcp import FastMCP
 
 from helpers import datagouv_api_client
 from helpers.logging import log_tool
+from helpers.mcp_tool_defaults import READ_ONLY_EXTERNAL_API_TOOL
 
 
 def register_list_dataset_resources_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(
+        title="List dataset resources",
+        annotations=READ_ONLY_EXTERNAL_API_TOOL,
+    )
     @log_tool
     async def list_dataset_resources(dataset_id: str) -> str:
         """

--- a/tools/query_resource_data.py
+++ b/tools/query_resource_data.py
@@ -5,12 +5,16 @@ from mcp.server.fastmcp import FastMCP
 
 from helpers import datagouv_api_client, tabular_api_client
 from helpers.logging import MAIN_LOGGER_NAME, log_tool
+from helpers.mcp_tool_defaults import READ_ONLY_EXTERNAL_API_TOOL
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
 
 def register_query_resource_data_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(
+        title="Query resource data",
+        annotations=READ_ONLY_EXTERNAL_API_TOOL,
+    )
     @log_tool
     async def query_resource_data(
         question: str,

--- a/tools/search_dataservices.py
+++ b/tools/search_dataservices.py
@@ -4,13 +4,17 @@ from mcp.server.fastmcp import FastMCP
 
 from helpers import datagouv_api_client
 from helpers.logging import MAIN_LOGGER_NAME, log_tool
+from helpers.mcp_tool_defaults import READ_ONLY_EXTERNAL_API_TOOL
 from tools.search_datasets import clean_search_query
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
 
 def register_search_dataservices_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(
+        title="Search dataservices",
+        annotations=READ_ONLY_EXTERNAL_API_TOOL,
+    )
     @log_tool
     async def search_dataservices(
         query: str, page: int = 1, page_size: int = 20

--- a/tools/search_datasets.py
+++ b/tools/search_datasets.py
@@ -4,6 +4,7 @@ from mcp.server.fastmcp import FastMCP
 
 from helpers import datagouv_api_client
 from helpers.logging import MAIN_LOGGER_NAME, log_tool
+from helpers.mcp_tool_defaults import READ_ONLY_EXTERNAL_API_TOOL
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
@@ -58,7 +59,10 @@ def clean_search_query(query: str) -> str:
 
 
 def register_search_datasets_tool(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(
+        title="Search datasets",
+        annotations=READ_ONLY_EXTERNAL_API_TOOL,
+    )
     @log_tool
     async def search_datasets(query: str, page: int = 1, page_size: int = 20) -> str:
         """


### PR DESCRIPTION
MCP clients can use tool metadata to label capabilities and safety hints (read-only vs destructive, external systems). This adds shared `ToolAnnotations` for our read-only public API tools and short human-readable titles, without changing tool behavior or responses.

EDIT: this was added following the [Anthropic MCP builder skill](https://github.com/anthropics/skills/blob/main/skills/mcp-builder/SKILL.md) which, when followed by LLM, suggests a few improvements to better follow the official MCP standard, one quick win one being that one.
See "Annotations" part in https://github.com/anthropics/skills/blob/main/skills/mcp-builder/SKILL.md#phase-2-implementation