### PR TITLE
chore(github): add issue/PR AI policy templates and reminder workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_general.yml
+++ b/.github/ISSUE_TEMPLATE/1_general.yml
@@ -1,0 +1,27 @@
+name: General issue
+description: Bug report, feature request, or other feedback
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### AI-generated content
+
+        **Raw AI-only issues (output you have not personally edited, fully understood, and vetted) are not allowed and may be closed without discussion.** By submitting, you state you understand this issue and can defend it without an AI.
+
+        All other rules (workflow, commits, review): **[Contributing guidelines](https://github.com/datagouv/datagouv-mcp/blob/main/README.md#contributing)**.
+
+  - type: checkboxes
+    id: human_accountability
+    attributes:
+      label: Confirmation
+      options:
+        - label: I am not submitting raw, unreviewed AI-generated content. I have reviewed, understand, and stand behind this issue.
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened, what you expected, and any steps to reproduce (for bugs).
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+### AI-generated content
+
+**Raw AI-only pull requests (code you have not personally edited, fully understood, and tested) are not allowed and may be closed without discussion.** By submitting, you state you understand this change and can defend it without an AI.
+
+All other rules (workflow, commits, review): **[Contributing guidelines](https://github.com/datagouv/datagouv-mcp/blob/main/README.md#contributing)**.
+
+#### Checklist
+
+- [ ] I am not submitting raw, unreviewed AI-generated content. I have reviewed, understand, and stand behind this PR.

--- a/.github/workflows/contribution-reminder.yml
+++ b/.github/workflows/contribution-reminder.yml
@@ -1,0 +1,62 @@
+name: Contribution reminder
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  post-reminder:
+    runs-on: ubuntu-latest
+    # Skip maintainers and repo collaborators; repeat the template blurb for others only.
+    if: |
+      (github.event_name == 'issues' &&
+        github.event.issue.author_association != 'OWNER' &&
+        github.event.issue.author_association != 'MEMBER' &&
+        github.event.issue.author_association != 'COLLABORATOR') ||
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.author_association != 'OWNER' &&
+        github.event.pull_request.author_association != 'MEMBER' &&
+        github.event.pull_request.author_association != 'COLLABORATOR')
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const isIssue = context.eventName === "issues";
+            const number = isIssue
+              ? context.payload.issue.number
+              : context.payload.pull_request.number;
+            const typePhrase = isIssue ? "issues" : "pull requests";
+            const scope = isIssue
+              ? "output you have not personally edited, understood, and vetted"
+              : "code you have not personally edited, understood, and tested";
+            const noun = isIssue ? "issue" : "change";
+            const link =
+              "https://github.com/" +
+              context.repo.owner +
+              "/" +
+              context.repo.repo +
+              "/blob/main/README.md#contributing";
+            const body =
+              "### AI-generated content\n\n" +
+              "**Raw AI-only " +
+              typePhrase +
+              " (" +
+              scope +
+              ") are not allowed and may be closed without discussion.** " +
+              "By submitting, you state you understand this " +
+              noun +
+              " and can defend it without an AI.\n\n" +
+              "All other rules: **[Contributing guidelines](" +
+              link +
+              ")**.";
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: body,
+            });

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ Steps:
 
 We welcome contributions! To keep the project stable and reviews manageable, please observe these rules before submitting:
 
-- **Human review and accountability:** Do not submit raw, unreviewed AI-generated code. Every change must be read, understood, tested, and validated by a human before you open a PR. **By submitting a pull request, you certify that you fully understand the proposed code and could explain and defend it in review without relying on an AI assistant.**
+- **Human review and accountability:** **Issues and pull requests** must not be raw, unreviewed AI output. You must have read, fully understood, and (for code) tested what you submit. **By opening an issue or a pull request, you certify you could explain and defend it in review without relying on an AI assistant.**
 - **Keep it small:** We strictly follow a **1 feature = 1 PR** workflow.
 - **Conventional commits:** Use the [Conventional Commits](https://www.conventionalcommits.org/) format for **git commit messages** and **PR titles** (e.g. `feat: add dataset search`, `fix: handle empty API response`). See the specification for allowed types, scopes, and breaking-change markers.
 


### PR DESCRIPTION
- Update the **Contributing** section in the README so the human-review and AI policy applies to **issues and pull requests** (not only code in PRs).

- Add a **required** GitHub **issue** template (no blank issues) with a short AI policy, link to `README#contributing`, a required confirmation checkbox, and a description field.

- Add a **pull request** template with the same policy and a checklist.

- Add a **workflow** that posts the same blurb as a comment on new issues/PRs for authors who are not OWNER, MEMBER, or COLLABORATOR (maintainers and collaborators are skipped).