### PR TITLE
feat(tools): align third-party API wording with dataservice identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ The MCP server is built using the [official Python SDK for MCP servers and clien
 
 The MCP server provides tools to interact with data.gouv.fr datasets and third-party APIs cataloged on the platform.
 
-**Note:** These APIs (e.g., Adresse API, Sirene API) are third-party services registered in the national open data catalog. data.gouv.fr exposes them over HTTP under the `dataservices` resource paths; that is separate from data.gouv.fr's own internal APIs (Main/Tabular/Metrics) that power this MCP server.
+**Note:** data.gouv.fr exposes these third-party APIs (e.g., Adresse API, Sirene API) over HTTP under the `dataservices` resource paths; that is separate from data.gouv.fr's own internal APIs (Main/Tabular/Metrics) that power this MCP server.
 
 ### Datasets (static data files)
 

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ The MCP server is built using the [official Python SDK for MCP servers and clien
 
 ## 🛠️ Available Tools
 
-The MCP server provides tools to interact with data.gouv.fr datasets and APIs cataloged on the platform.
+The MCP server provides tools to interact with data.gouv.fr datasets and third-party APIs cataloged on the platform.
 
 **Note:** These APIs (e.g., Adresse API, Sirene API) are third-party services registered in the national open data catalog. data.gouv.fr exposes them over HTTP under the `dataservices` resource paths; that is separate from data.gouv.fr's own internal APIs (Main/Tabular/Metrics) that power this MCP server.
 

--- a/README.md
+++ b/README.md
@@ -356,9 +356,9 @@ The MCP server is built using the [official Python SDK for MCP servers and clien
 
 ## 🛠️ Available Tools
 
-The MCP server provides tools to interact with data.gouv.fr datasets and dataservices.
+The MCP server provides tools to interact with data.gouv.fr datasets and APIs cataloged on the platform.
 
-**Note:** "Dataservices" are external third-party APIs (e.g., Adresse API, Sirene API) registered in the data.gouv.fr catalog. They are distinct from data.gouv.fr's own internal APIs (Main/Tabular/Metrics) which power this MCP server.
+**Note:** These APIs (e.g., Adresse API, Sirene API) are third-party services registered in the national open data catalog. data.gouv.fr exposes them over HTTP under the `dataservices` resource paths; that is separate from data.gouv.fr's own internal APIs (Main/Tabular/Metrics) that power this MCP server.
 
 ### Datasets (static data files)
 
@@ -388,21 +388,23 @@ The MCP server provides tools to interact with data.gouv.fr datasets and dataser
 
   Note: Recommended workflow: 1) Use `search_datasets` to find the dataset, 2) Use `list_dataset_resources` to see available resources, 3) Use `query_resource_data` with default `page_size` (20) to preview data structure. For small datasets (<500 rows), increase `page_size` or paginate. For large datasets (>1000 rows), continue paginating or use `get_resource_info` to retrieve the raw file URL and fetch it directly. Works for CSV/XLS resources within Tabular API size limits (CSV ≤ 100 MB, XLSX ≤ 12.5 MB).
 
-### Dataservices (external APIs)
+### Third-party APIs
 
-- **`search_dataservices`** - Search for dataservices (APIs) registered on data.gouv.fr by keywords. Returns dataservices with metadata (title, description, organization, base API URL, tags).
+These tools use data.gouv.fr HTTP paths under `dataservices`; tool and parameter names match that API (`search_dataservices`, `dataservice_id`).
+
+- **`search_dataservices`** - Search for third-party APIs cataloged on data.gouv.fr by keywords. Returns entries with metadata (title, description, organization, base API URL, tags).
 
   Parameters: `query` (required), `page` (optional, default: 1), `page_size` (optional, default: 20, max: 100)
 
-- **`get_dataservice_info`** - Get detailed metadata about a specific dataservice (title, description, organization, base API URL, OpenAPI spec URL, license, dates, related datasets).
+- **`get_dataservice_info`** - Get detailed metadata for one third-party API (title, description, organization, base API URL, OpenAPI spec URL, license, dates, related datasets).
+
+  Parameters: `dataservice_id` (required) — same as in the data.gouv.fr API and as the `id` from search results.
+
+- **`get_dataservice_openapi_spec`** - Fetch and summarize the OpenAPI/Swagger specification for a third-party API. Returns a concise overview of available endpoints with their parameters.
 
   Parameters: `dataservice_id` (required)
 
-- **`get_dataservice_openapi_spec`** - Fetch and summarize the OpenAPI/Swagger specification for a dataservice. Returns a concise overview of available endpoints with their parameters.
-
-  Parameters: `dataservice_id` (required)
-
-  Note: Recommended workflow: 1) Use `search_dataservices` to find the API, 2) Use `get_dataservice_info` to get its metadata and documentation URL, 3) Use `get_dataservice_openapi_spec` to understand available endpoints and parameters, 4) Call the API using the `base_api_url` per the spec.
+  Note: Recommended workflow: 1) Use `search_dataservices` to find the API, 2) Use `get_dataservice_info` for metadata and documentation URL, 3) Use `get_dataservice_openapi_spec` for endpoints and parameters, 4) Call the API using the `base_api_url` per the spec.
 
 ### Metrics
 

--- a/helpers/datagouv_api_client.py
+++ b/helpers/datagouv_api_client.py
@@ -194,7 +194,7 @@ async def get_dataservice_details(
     dataservice_id: str, session: httpx.AsyncClient | None = None
 ) -> dict[str, Any]:
     """
-    Fetch the complete dataservice payload from the API v1 endpoint.
+    Fetch the full catalog payload for a third-party API from GET /1/dataservices/{id}/.
     """
     own = session is None
     if own:
@@ -216,7 +216,7 @@ async def search_dataservices(
     session: httpx.AsyncClient | None = None,
 ) -> dict[str, Any]:
     """
-    Search for dataservices (APIs) on data.gouv.fr.
+    Search third-party APIs cataloged on data.gouv.fr via GET /2/dataservices/search/.
 
     Args:
         query: Search query string
@@ -224,7 +224,7 @@ async def search_dataservices(
         page_size: Number of results per page (default: 20, max: 100)
 
     Returns:
-        dict with 'data' (list of dataservices), 'page', 'page_size', and 'total'
+        dict with 'data' (list of third-party API entries), 'page', 'page_size', and 'total'
     """
     own = session is None
     if own:
@@ -242,9 +242,9 @@ async def search_dataservices(
         resp.raise_for_status()
         data = resp.json()
 
-        dataservices: list[dict[str, Any]] = data.get("data", [])
+        raw_items: list[dict[str, Any]] = data.get("data", [])
         results: list[dict[str, Any]] = []
-        for ds in dataservices:
+        for ds in raw_items:
             tags: list[str] = ds.get("tags") or []
 
             results.append(

--- a/helpers/datagouv_api_client.py
+++ b/helpers/datagouv_api_client.py
@@ -244,21 +244,21 @@ async def search_dataservices(
 
         raw_items: list[dict[str, Any]] = data.get("data", [])
         results: list[dict[str, Any]] = []
-        for ds in raw_items:
-            tags: list[str] = ds.get("tags") or []
+        for item in raw_items:
+            tags: list[str] = item.get("tags") or []
 
             results.append(
                 {
-                    "id": ds.get("id"),
-                    "title": ds.get("title") or "",
-                    "description": ds.get("description", ""),
-                    "organization": ds.get("organization", {}).get("name")
-                    if ds.get("organization")
+                    "id": item.get("id"),
+                    "title": item.get("title") or "",
+                    "description": item.get("description", ""),
+                    "organization": item.get("organization", {}).get("name")
+                    if item.get("organization")
                     else None,
-                    "base_api_url": ds.get("base_api_url"),
-                    "machine_documentation_url": ds.get("machine_documentation_url"),
+                    "base_api_url": item.get("base_api_url"),
+                    "machine_documentation_url": item.get("machine_documentation_url"),
                     "tags": tags,
-                    "url": f"{env_config.get_base_url('site')}dataservices/{ds.get('id', '')}",
+                    "url": f"{env_config.get_base_url('site')}dataservices/{item.get('id', '')}",
                 }
             )
 

--- a/tests/test_datagouv_api.py
+++ b/tests/test_datagouv_api.py
@@ -177,7 +177,7 @@ class TestAsyncFunctions:
         assert isinstance(details.get("resources", []), list)
 
     async def test_search_dataservices_basic(self):
-        """Test basic dataservice search."""
+        """Test basic third-party API search."""
         result = await datagouv_api_client.search_dataservices(
             "adresse", page=1, page_size=5
         )
@@ -190,7 +190,7 @@ class TestAsyncFunctions:
         assert isinstance(result["data"], list)
 
     async def test_search_dataservices_structure(self):
-        """Test that dataservice search results have correct structure."""
+        """Test that third-party API search results have correct structure."""
         result = await datagouv_api_client.search_dataservices("adresse", page_size=2)
 
         if result["data"]:
@@ -200,12 +200,12 @@ class TestAsyncFunctions:
             assert "url" in ds
             assert "tags" in ds
             assert isinstance(ds["tags"], list)
-            # Dataservice-specific fields
+            # Third-party API-specific fields
             assert "base_api_url" in ds
             assert "machine_documentation_url" in ds
 
     async def test_search_dataservices_empty_query(self):
-        """Test dataservice search with empty query."""
+        """Test third-party API search with empty query."""
         result = await datagouv_api_client.search_dataservices("", page_size=1)
         assert "data" in result
         assert isinstance(result["data"], list)
@@ -315,7 +315,7 @@ class TestAsyncFunctions:
         assert len(result["data"]) <= 100
 
     async def test_get_dataservice_details(self):
-        """Test fetching full dataservice details payload."""
+        """Test fetching full third-party API details payload."""
         # API Adresse (BAN) — known to have base_api_url and machine_documentation_url
         dataservice_id = "672cf67802ef6b1be63b8975"
         details = await datagouv_api_client.get_dataservice_details(dataservice_id)
@@ -326,7 +326,7 @@ class TestAsyncFunctions:
         assert details.get("machine_documentation_url")
 
     async def test_get_dataservice_details_invalid_id(self):
-        """Test that invalid dataservice ID raises error."""
+        """Test that an invalid dataservice_id raises an error."""
         invalid_id = "000000000000000000000000"
         with pytest.raises(Exception):
             await datagouv_api_client.get_dataservice_details(invalid_id)

--- a/tools/get_dataservice_info.py
+++ b/tools/get_dataservice_info.py
@@ -10,25 +10,25 @@ from helpers.mcp_tool_defaults import READ_ONLY_EXTERNAL_API_TOOL
 
 def register_get_dataservice_info_tool(mcp: FastMCP) -> None:
     @mcp.tool(
-        title="Get dataservice info",
+        title="Get third-party API info",
         annotations=READ_ONLY_EXTERNAL_API_TOOL,
     )
     @log_tool
     async def get_dataservice_info(dataservice_id: str) -> str:
         """
-        Get detailed metadata about a specific dataservice (external third-party API).
+        Get detailed metadata about a specific third-party API (dataservice).
 
         Returns title, description, organization, base_api_url,
         machine_documentation_url (OpenAPI/Swagger spec), license, and dates.
 
-        To use a dataservice: (1) get its info here, (2) fetch the OpenAPI spec
+        To use a third-party API: (1) get its info here, (2) fetch the OpenAPI spec
         via get_dataservice_openapi_spec, (3) call base_api_url per spec.
         """
         try:
             data = await datagouv_api_client.get_dataservice_details(dataservice_id)
 
             content_parts = [
-                f"Dataservice Information: {data.get('title', 'Unknown')}",
+                f"Third-party API information: {data.get('title', 'Unknown')}",
                 "",
             ]
 
@@ -43,7 +43,7 @@ def register_get_dataservice_info_tool(mcp: FastMCP) -> None:
                 desc = data.get("description", "")[:500]
                 content_parts.append(f"Description: {desc}...")
 
-            # Key dataservice fields
+            # Catalog resource fields for this third-party API (dataservice)
             content_parts.append("")
             if data.get("base_api_url"):
                 content_parts.append(f"Base API URL: {data.get('base_api_url')}")
@@ -87,7 +87,7 @@ def register_get_dataservice_info_tool(mcp: FastMCP) -> None:
 
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
-                return f"Error: Dataservice with ID '{dataservice_id}' not found."
+                return f"Error: Third-party API not found (dataservice_id='{dataservice_id}')."
             return f"Error: HTTP {e.response.status_code} - {str(e)}"
         except Exception as e:  # noqa: BLE001
             return f"Error: {str(e)}"

--- a/tools/get_dataservice_openapi_spec.py
+++ b/tools/get_dataservice_openapi_spec.py
@@ -87,15 +87,15 @@ def _summarize_spec(spec: dict[str, Any]) -> str:
 
 def register_get_dataservice_openapi_spec_tool(mcp: FastMCP) -> None:
     @mcp.tool(
-        title="Get dataservice OpenAPI spec",
+        title="Get third-party API OpenAPI spec",
         annotations=READ_ONLY_EXTERNAL_API_TOOL,
     )
     @log_tool
     async def get_dataservice_openapi_spec(dataservice_id: str) -> str:
         """
-        Fetch and summarize the OpenAPI/Swagger spec for a dataservice (external third-party API).
+        Fetch and summarize the OpenAPI/Swagger spec for a third-party API (dataservice).
 
-        Retrieves the machine_documentation_url from the dataservice metadata,
+        Retrieves machine_documentation_url from catalog metadata (dataservice record),
         fetches the spec, and returns a summary of available endpoints with
         their parameters. Use this to understand how to call the API.
 
@@ -110,7 +110,10 @@ def register_get_dataservice_openapi_spec_tool(mcp: FastMCP) -> None:
             title = data.get("title", "Unknown")
 
             if not doc_url:
-                msg = f"Dataservice '{title}' has no machine_documentation_url."
+                msg = (
+                    f"Third-party API '{title}' has no machine_documentation_url "
+                    "(dataservice catalog entry)."
+                )
                 if base_api_url:
                     msg += f" Base API URL is: {base_api_url}"
                 return msg
@@ -131,7 +134,7 @@ def register_get_dataservice_openapi_spec_tool(mcp: FastMCP) -> None:
 
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
-                return f"Error: Dataservice with ID '{dataservice_id}' not found."
+                return f"Error: Third-party API not found (dataservice_id='{dataservice_id}')."
             return f"Error: HTTP {e.response.status_code} - {str(e)}"
         except Exception as e:  # noqa: BLE001
             return f"Error fetching OpenAPI spec: {str(e)}"

--- a/tools/search_dataservices.py
+++ b/tools/search_dataservices.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(MAIN_LOGGER_NAME)
 
 def register_search_dataservices_tool(mcp: FastMCP) -> None:
     @mcp.tool(
-        title="Search dataservices",
+        title="Search third-party APIs",
         annotations=READ_ONLY_EXTERNAL_API_TOOL,
     )
     @log_tool
@@ -20,9 +20,9 @@ def register_search_dataservices_tool(mcp: FastMCP) -> None:
         query: str, page: int = 1, page_size: int = 20
     ) -> str:
         """
-        Search for dataservices (external third-party APIs) on data.gouv.fr by keywords.
+        Search for third-party APIs (dataservices) on data.gouv.fr by keywords.
 
-        Dataservices are third-party APIs registered in the data.gouv.fr catalog
+        Third-party APIs (or dataservices) are APIs registered in the data.gouv.fr catalog
         that provide programmatic access to data (unlike datasets which are static files).
         Use short, specific queries (the API uses AND logic, so generic words
         like "données" or "fichier" may return zero results).
@@ -50,10 +50,10 @@ def register_search_dataservices_tool(mcp: FastMCP) -> None:
             dataservices = result.get("data", [])
 
         if not dataservices:
-            return f"No dataservices found for query: '{query}'"
+            return f"No third-party APIs found for query: '{query}'"
 
         content_parts = [
-            f"Found {result.get('total', len(dataservices))} dataservice(s) for query: '{query}'",
+            f"Found {result.get('total', len(dataservices))} third-party API(s) for query: '{query}'",
             f"Page {result.get('page', 1)} of results:\n",
         ]
         for i, ds in enumerate(dataservices, 1):


### PR DESCRIPTION
## Naming disambiguation between APIs and dataservices

Agents and readers need language that is clearer than "dataservices" to designate third-party APIs, while distinguishing catalogued third-party HTTP APIs from data.gouv.fr’s own platform APIs, and without renaming tools away from the public API’s `dataservices` path vocabulary. 

This updates MCP tool titles, tool output, and error messages to use clearer and consistent naming. The README catalog section is corrected so documented tool names match what the server registers, and API client docstrings are cleaned up for grammar and clarity.