### PR TITLE
feat: add sort and last_update_range params to search_datasets

### DIFF
--- a/helpers/datagouv_api_client.py
+++ b/helpers/datagouv_api_client.py
@@ -288,8 +288,8 @@ async def search_datasets(
         query: Search query string (searches in title, description, tags)
         page: Page number (default: 1)
         page_size: Number of results per page (default: 20, max: 100)
-        sort: Sort field, optionally prefixed with '-' for descending. Examples:
-            created, -created, title, -title.
+        sort: Sort field. Accepted values: created, last_update, reuses,
+            followers, views. Optionally prefixed with '-' for descending.
         last_update_range: Filter datasets by their last update date. Allowed
             values: last_30_days, last_12_months, last_3_years.
 

--- a/helpers/datagouv_api_client.py
+++ b/helpers/datagouv_api_client.py
@@ -277,6 +277,8 @@ async def search_datasets(
     query: str,
     page: int = 1,
     page_size: int = 20,
+    sort: str | None = None,
+    last_update_range: str | None = None,
     session: httpx.AsyncClient | None = None,
 ) -> dict[str, Any]:
     """
@@ -286,6 +288,10 @@ async def search_datasets(
         query: Search query string (searches in title, description, tags)
         page: Page number (default: 1)
         page_size: Number of results per page (default: 20, max: 100)
+        sort: Sort field, optionally prefixed with '-' for descending. Examples:
+            created, -created, title, -title.
+        last_update_range: Filter datasets by their last update date. Allowed
+            values: last_30_days, last_12_months, last_3_years.
 
     Returns:
         dict with 'data' (list of datasets), 'page', 'page_size', and 'total'
@@ -298,11 +304,15 @@ async def search_datasets(
         base_url: str = env_config.get_base_url("datagouv_api")
         # Use API v2 for dataset search
         url = f"{base_url}2/datasets/search/"
-        params = {
+        params: dict[str, Any] = {
             "q": query,
             "page": page,
             "page_size": min(page_size, 100),  # API limit
         }
+        if sort:
+            params["sort"] = sort
+        if last_update_range:
+            params["last_update_range"] = last_update_range
         resp = await session.get(url, params=params, timeout=15.0)
         resp.raise_for_status()
         data = resp.json()

--- a/tests/test_datagouv_api.py
+++ b/tests/test_datagouv_api.py
@@ -158,6 +158,53 @@ class TestAsyncFunctions:
         assert "data" in result
         assert isinstance(result["data"], list)
 
+    async def test_search_datasets_passes_optional_params(self):
+        """search_datasets forwards sort and last_update_range to the API."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": [], "total": 0}
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        await datagouv_api_client.search_datasets(
+            query="IRVE",
+            page=2,
+            page_size=10,
+            sort="-created",
+            last_update_range="last_30_days",
+            session=mock_client,
+        )
+
+        mock_client.get.assert_called_once()
+        _args, kwargs = mock_client.get.call_args
+        assert "2/datasets/search/" in _args[0]
+        assert kwargs["params"] == {
+            "q": "IRVE",
+            "page": 2,
+            "page_size": 10,
+            "sort": "-created",
+            "last_update_range": "last_30_days",
+        }
+
+    async def test_search_datasets_omits_none_optional_params(self):
+        """None sort and last_update_range are not sent to the API."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": [], "total": 0}
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        await datagouv_api_client.search_datasets(
+            query="transport",
+            page=1,
+            page_size=5,
+            session=mock_client,
+        )
+
+        _args, kwargs = mock_client.get.call_args
+        assert "sort" not in kwargs["params"]
+        assert "last_update_range" not in kwargs["params"]
+
     async def test_get_resource_details(self, known_resource_id):
         """Test fetching full resource details payload."""
         details = await datagouv_api_client.get_resource_details(known_resource_id)

--- a/tools/search_datasets.py
+++ b/tools/search_datasets.py
@@ -64,13 +64,24 @@ def register_search_datasets_tool(mcp: FastMCP) -> None:
         annotations=READ_ONLY_EXTERNAL_API_TOOL,
     )
     @log_tool
-    async def search_datasets(query: str, page: int = 1, page_size: int = 20) -> str:
+    async def search_datasets(
+        query: str,
+        page: int = 1,
+        page_size: int = 20,
+        sort: str | None = None,
+        last_update_range: str | None = None,
+    ) -> str:
         """
         Search for datasets on data.gouv.fr by keywords.
 
         This is typically the first step in exploring data.gouv.fr.
         Use short, specific queries (the API uses AND logic, so generic words
         like "données" or "fichier" may return zero results).
+
+        Use `sort` to order results (e.g. created, -created, title, -title).
+        A leading '-' means descending order. Use `last_update_range` to restrict
+        results to recently updated datasets: last_30_days, last_12_months,
+        last_3_years.
 
         Typical workflow: search_datasets → list_dataset_resources → query_resource_data.
         """
@@ -79,7 +90,11 @@ def register_search_datasets_tool(mcp: FastMCP) -> None:
 
         # Try with cleaned query first
         result = await datagouv_api_client.search_datasets(
-            query=cleaned_query, page=page, page_size=page_size
+            query=cleaned_query,
+            page=page,
+            page_size=page_size,
+            sort=sort,
+            last_update_range=last_update_range,
         )
 
         # Format the result as text content
@@ -94,7 +109,11 @@ def register_search_datasets_tool(mcp: FastMCP) -> None:
                 query,
             )
             result = await datagouv_api_client.search_datasets(
-                query=query, page=page, page_size=page_size
+                query=query,
+                page=page,
+                page_size=page_size,
+                sort=sort,
+                last_update_range=last_update_range,
             )
             datasets = result.get("data", [])
 

--- a/tools/search_datasets.py
+++ b/tools/search_datasets.py
@@ -78,8 +78,9 @@ def register_search_datasets_tool(mcp: FastMCP) -> None:
         Use short, specific queries (the API uses AND logic, so generic words
         like "données" or "fichier" may return zero results).
 
-        Use `sort` to order results (e.g. created, -created, title, -title).
-        A leading '-' means descending order. Use `last_update_range` to restrict
+        Use `sort` to order results. Accepted values: created, last_update,
+        reuses, followers, views. Optionally prefixed with '-' for descending
+        (e.g. -last_update). Use `last_update_range` to restrict
         results to recently updated datasets: last_30_days, last_12_months,
         last_3_years.
 


### PR DESCRIPTION
Closes #19 (sort) and #104 (last_update_range).

## What

The data.gouv.fr v2 search API supports both `sort` and `last_update_range` query parameters, but they were not exposed by the `search_datasets` MCP tool or its underlying client function.

## Changes

- **`helpers/datagouv_api_client.py`**: add optional `sort: str | None` and `last_update_range: str | None` to `search_datasets()`; parameters are only forwarded to the API when not `None`, keeping backward compatibility
- **`tools/search_datasets.py`**: expose the two new params in the MCP tool function and thread them through both the primary and the fallback calls
- **`tests/test_datagouv_api.py`**: two new unit tests — one verifying the params are forwarded correctly, one verifying they are omitted when `None`

## Why

This mirrors the `sort` parameter already available on `search_organizations` and follows the same implementation pattern. Without `sort`, the most recently updated (and often most relevant) dataset may never surface in results — as illustrated in #19 with the consolidated IRVE dataset. Without `last_update_range`, there is no way to scope a search to recently updated datasets without leaving the MCP.

Allowed values documented in the tool docstring:
- `sort`: `created`, `-created`, `title`, `-title`
- `last_update_range`: `last_30_days`, `last_12_months`, `last_3_years`

## Testing

All 83 existing tests pass. Two new unit tests added. Ruff and ty both clean.

```
uv run pytest -v            # 83 passed
uv run ruff check --fix .   # All checks passed
uv run ty check             # All checks passed
```