### PR TITLE
fix: report real resource count from resources.total in search_datasets

### DIFF
--- a/helpers/datagouv_api_client.py
+++ b/helpers/datagouv_api_client.py
@@ -324,7 +324,7 @@ async def search_datasets(
                     if ds.get("organization")
                     else None,
                     "tags": tags,
-                    "resources_count": len(ds.get("resources", [])),
+                    "resources_count": ds.get("resources", {}).get("total", 0),
                     "url": f"{env_config.get_base_url('site')}datasets/{ds.get('slug', ds.get('id', ''))}",
                 }
             )

--- a/tests/test_datagouv_api.py
+++ b/tests/test_datagouv_api.py
@@ -158,6 +158,29 @@ class TestAsyncFunctions:
         assert "data" in result
         assert isinstance(result["data"], list)
 
+    async def test_search_datasets_resources_length(self):
+        """Test search_datasets reports the real resource count from resources.total."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {"resources": {"rel": "...", "href": "...", "type": "...", "total": 3}},
+                {"resources": {"rel": "...", "href": "...", "type": "...", "total": 7}},
+            ],
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.aclose = AsyncMock(return_value=None)
+
+        with patch(
+            "helpers.datagouv_api_client.httpx.AsyncClient",
+            return_value=mock_client,
+        ):
+            result = await datagouv_api_client.search_datasets("", page_size=1)
+
+        assert result["data"][0]["resources_count"] == 3
+        assert result["data"][1]["resources_count"] == 7
+
     async def test_get_resource_details(self, known_resource_id):
         """Test fetching full resource details payload."""
         details = await datagouv_api_client.get_resource_details(known_resource_id)


### PR DESCRIPTION
## What
`search_datasets` reported `resources_count: 4` for every dataset.

## Why
In the `GET /2/datasets/search/` payload, `resources` is a HATEOAS link dict `{rel, href, type, total}`, not a list, so `len(ds.get("resources", []))` counted the 4 dict keys for every dataset. The real count is in `resources.total`.

## Fix
Read `resources.total` instead of `len(resources)`. One-line change in `helpers/datagouv_api_client.py`.

## Testing

Added `test_search_datasets_resources_length` (mocked transport, two datasets with totals 3 and 7). 

- `pytest` - 27 passed (full `tests/test_datagouv_api.py`)
- `uv run pytest -v` - 82 passed (entire test suite)
- `uv run ruff check --fix .` - all passed
- `uv run ty check `  clean 

Closes #114 

### AI-generated content

**Raw AI-only pull requests (code you have not personally edited, fully understood, and tested) are not allowed and may be closed without discussion.** By submitting, you state you understand this change and can defend it without an AI.

All other rules (workflow, commits, review): **[Contributing guidelines](https://github.com/datagouv/datagouv-mcp/blob/main/README.md#contributing)**.

#### Checklist

- [x] I am not submitting raw, unreviewed AI-generated content. I have reviewed, understand, and stand behind this PR.
