### PR TITLE
fix(matomo): remove matomo request on/mcp, keep only tools events

### DIFF
--- a/helpers/matomo.py
+++ b/helpers/matomo.py
@@ -63,25 +63,6 @@ async def _post_matomo(payload: dict) -> None:
         )
 
 
-async def track_matomo_request(url: str, path: str, headers: dict[str, str]) -> None:
-    """Track one HTTP-level MCP request (page-action style)."""
-    user_agent = headers.get("user-agent", "")
-    payload = {
-        "idsite": MATOMO_SITE_ID,
-        "rec": 1,
-        "url": url,
-        "action_name": f"MCP Request: {path}",
-        "ua": user_agent,
-        "rand": str(random.randint(10**15, 10**16 - 1)),
-    }
-    if MATOMO_AUTH_TOKEN:
-        payload["token_auth"] = MATOMO_AUTH_TOKEN
-        cip = headers.get("x-forwarded-for", "").split(",")[0].strip()
-        if cip:
-            payload["cip"] = cip
-    await _post_matomo(payload)
-
-
 async def track_matomo_tool(tool_name: str) -> None:
     """
     Track an MCP tool invocation as a Matomo event (Behavior > Events).

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 import os
@@ -16,7 +15,6 @@ from helpers.logging import MAIN_LOGGER_NAME, UVICORN_LOGGING_CONFIG
 from helpers.matomo import (
     apply_matomo_request_context,
     reset_matomo_request_context,
-    track_matomo_request,
 )
 from helpers.sentry import init_sentry
 from tools import register_tools
@@ -105,7 +103,7 @@ def with_monitoring(
                 await send({"type": "http.response.body", "body": body})
                 return
 
-            # Matomo: bind request URL/UA for tool event tracking; HTTP-level hit in background
+            # Matomo: bind request URL/UA for tool event tracking
             headers_dict: dict[str, str] = {
                 k.decode("utf-8"): v.decode("utf-8")
                 for k, v in scope.get("headers", [])
@@ -113,12 +111,7 @@ def with_monitoring(
             url_token, ua_token, cip_token = apply_matomo_request_context(
                 headers_dict, path
             )
-            host: str = headers_dict.get("host", "localhost")
-            full_url: str = f"https://{host}{path}"
             try:
-                asyncio.create_task(
-                    track_matomo_request(url=full_url, path=path, headers=headers_dict)
-                )
                 await inner_app(scope, receive, send)
             finally:
                 reset_matomo_request_context(url_token, ua_token, cip_token)

--- a/tests/test_matomo.py
+++ b/tests/test_matomo.py
@@ -8,37 +8,6 @@ import helpers.matomo as matomo
 
 
 @pytest.mark.asyncio
-async def test_track_matomo_request_sends_expected_form_fields(
-    httpx_mock,
-    monkeypatch,
-):
-    monkeypatch.setattr(matomo, "MATOMO_URL", "https://matomo.example")
-    monkeypatch.setattr(matomo, "MATOMO_SITE_ID", "7")
-    monkeypatch.setattr(matomo, "MATOMO_AUTH_TOKEN", "tok")
-    httpx_mock.add_response()
-
-    await matomo.track_matomo_request(
-        "https://mcp.example/mcp",
-        "/mcp",
-        {"user-agent": "MCPTest/1"},
-    )
-
-    requests = httpx_mock.get_requests()
-    assert len(requests) == 1
-    assert str(requests[0].url) == "https://matomo.example/matomo.php"
-    body = requests[0].content.decode()
-    params = parse_qs(body, strict_parsing=True)
-    assert params["idsite"] == ["7"]
-    assert params["rec"] == ["1"]
-    assert params["url"] == ["https://mcp.example/mcp"]
-    assert params["action_name"] == ["MCP Request: /mcp"]
-    assert params["ua"] == ["MCPTest/1"]
-    assert params["token_auth"] == ["tok"]
-    assert "e_c" not in params
-    assert "ca" not in params
-
-
-@pytest.mark.asyncio
 async def test_track_matomo_tool_sends_event_fields(httpx_mock, monkeypatch):
     monkeypatch.setattr(matomo, "MATOMO_URL", "https://matomo.example")
     monkeypatch.setattr(matomo, "MATOMO_SITE_ID", "7")
@@ -64,25 +33,6 @@ async def test_track_matomo_tool_sends_event_fields(httpx_mock, monkeypatch):
     assert params["url"] == ["https://mcp.example/mcp"]
     assert params["ua"] == ["ToolUA/2"]
     assert "token_auth" not in params
-
-
-@pytest.mark.asyncio
-async def test_track_matomo_request_forwards_cip(httpx_mock, monkeypatch):
-    monkeypatch.setattr(matomo, "MATOMO_URL", "https://matomo.example")
-    monkeypatch.setattr(matomo, "MATOMO_SITE_ID", "7")
-    monkeypatch.setattr(matomo, "MATOMO_AUTH_TOKEN", "tok")
-    httpx_mock.add_response()
-
-    await matomo.track_matomo_request(
-        "https://mcp.example/mcp",
-        "/mcp",
-        {"user-agent": "MCPTest/1", "x-forwarded-for": "203.0.113.42, 198.51.100.2"},
-    )
-
-    body = httpx_mock.get_requests()[0].content.decode()
-    params = parse_qs(body, strict_parsing=True)
-    assert params["cip"] == ["203.0.113.42"]
-    assert params["token_auth"] == ["tok"]
 
 
 @pytest.mark.asyncio
@@ -114,9 +64,5 @@ async def test_track_matomo_tool_forwards_cip_from_context(httpx_mock, monkeypat
 async def test_post_matomo_skips_when_not_configured(httpx_mock, monkeypatch):
     monkeypatch.setattr(matomo, "MATOMO_URL", "")
     monkeypatch.setattr(matomo, "MATOMO_SITE_ID", "1")
-    await matomo.track_matomo_request(
-        "https://x/y",
-        "/y",
-        {},
-    )
+    await matomo.track_matomo_tool("search_datasets")
     assert len(httpx_mock.get_requests()) == 0


### PR DESCRIPTION
Trying to fix [PoolTimeOut errors to Matomo](https://errors.data.gouv.fr/organizations/sentry/issues/295807/?project=41&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=0):

Matomo was sending two tracking calls per MCP interaction (one HTTP hit on /mcp and one tool event), which might be saturating the shared httpx connection pool and triggered PoolTimeout errors in Sentry. Tool events already capture the usage we care about (which tool was called, with request context), so the HTTP-level page view was redundant. This PR removes the background `track_matomo_request` call while keeping `apply_matomo_request_context` so tool events still get URL, User-Agent, and client IP. Matomo traffic is roughly halved on the common path, which should significantly reduce pool saturation without losing meaningful analytics.





### AI-generated content

**Raw AI-only pull requests (code you have not personally edited, fully understood, and tested) are not allowed and may be closed without discussion.** By submitting, you state you understand this change and can defend it without an AI.

All other rules (workflow, commits, review): **[Contributing guidelines](https://github.com/datagouv/datagouv-mcp/blob/main/README.md#contributing)**.

#### Checklist

- [x] I am not submitting raw, unreviewed AI-generated content. I have reviewed, understand, and stand behind this PR.
