### PR TITLE
fix(health): run health probe in-process to avoid FD leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ The MCP server is built using the [official Python SDK for MCP servers and clien
 
 **Streamable HTTP transport (standards-compliant):**
 - `POST /mcp` - JSON-RPC messages (client → server)
-- `GET /health` - Health check endpoint: runs a full MCP handshake and tool call. Returns `{"status":"ok",...}` with HTTP 200 if healthy, or `{"status":"mcp_unavailable"}` with HTTP 503 if the MCP stack is not responding correctly.
+- `GET /health` - Health check endpoint: runs `search_datasets` in-process (no recursive HTTP call). Returns `{"status":"ok",...}` with HTTP 200 if healthy, or `{"status":"mcp_unavailable"}` with HTTP 503 if the MCP stack is not responding correctly.
 
 ## 🛠️ Available Tools
 
@@ -450,10 +450,9 @@ Currently includes a test that mixes normal requests with abrupt client TCP disc
 
 ### 🩺 Run a Health Check from the CLI
 
-Runs a full MCP handshake and calls `search_datasets` to validate end-to-end stack health. Requires a running server and is excluded from default `pytest` runs.
+Runs `search_datasets` in-process to validate end-to-end stack health (tool layer + data.gouv.fr API). Requires network access to data.gouv.fr. Excluded from default `pytest` runs.
 
 ```shell
-# Start the server first, then in another terminal:
 uv run pytest -m health_check
 ```
 

--- a/helpers/health_probe.py
+++ b/helpers/health_probe.py
@@ -25,11 +25,10 @@ async def _run_health_check(mcp: FastMCP) -> bool:
             {"query": "transport", "page_size": 1},
         )
         # search_datasets always returns a TextContent block
-        # we check it's non-empty to confirm a valid round-trip
-        if not content or not isinstance(content[0], TextContent):
+        if not content or not isinstance(content[0], TextContent):  # type: ignore
             logger.error("health probe: unexpected response from search_datasets")
             return False
-        if not content[0].text:
+        if not content[0].text:  # type: ignore
             logger.error("health probe: empty response from search_datasets")
             return False
 

--- a/helpers/health_probe.py
+++ b/helpers/health_probe.py
@@ -1,36 +1,35 @@
 """
-Health probe that runs a check on the MCP itself (doing a full handshake)
-and calls the `search_datasets` tool with page_size=1 for a full round-trip validation.
+Health probe that validates MCP tool execution in-process.
 
-Checks if the call response actually contains `data` for valid MCP response
+Calls `search_datasets` with page_size=1 to confirm the tool layer and
+data.gouv.fr API access work end-to-end, without a recursive HTTP round-trip.
 
-returns True if OK
-        False if round-trip failed (meaning the probe failed)
+Returns True if OK, False if the probe failed.
 """
 
 import logging
 
+from mcp.server.fastmcp import FastMCP
 from mcp.types import TextContent
 
 from helpers.logging import MAIN_LOGGER_NAME
-from helpers.mcp_client import call_tool_on_mcp
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
 
-async def _run_health_check() -> bool:
+async def _run_health_check(mcp: FastMCP) -> bool:
     logger.debug("health probe: starting health check")
     try:
-        result = await call_tool_on_mcp(
-            "search_datasets", {"query": "transport", "page_size": 1}
+        content, _ = await mcp.call_tool(
+            "search_datasets",
+            {"query": "transport", "page_size": 1},
         )
-        # result.content is a list of content blocks from the tool response
         # search_datasets always returns a TextContent block
         # we check it's non-empty to confirm a valid round-trip
-        if not result.content or not isinstance(result.content[0], TextContent):
+        if not content or not isinstance(content[0], TextContent):
             logger.error("health probe: unexpected response from search_datasets")
             return False
-        if not result.content[0].text:
+        if not content[0].text:
             logger.error("health probe: empty response from search_datasets")
             return False
 

--- a/helpers/health_probe.py
+++ b/helpers/health_probe.py
@@ -13,6 +13,10 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import TextContent
 
 from helpers.logging import MAIN_LOGGER_NAME
+from helpers.matomo import (
+    apply_matomo_tool_event_action,
+    reset_matomo_tool_event_action,
+)
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
@@ -20,10 +24,14 @@ logger = logging.getLogger(MAIN_LOGGER_NAME)
 async def _run_health_check(mcp: FastMCP) -> bool:
     logger.debug("health probe: starting health check")
     try:
-        content, _ = await mcp.call_tool(
-            "search_datasets",
-            {"query": "transport", "page_size": 1},
-        )
+        action_token = apply_matomo_tool_event_action("health_check")
+        try:
+            content, _ = await mcp.call_tool(
+                "search_datasets",
+                {"query": "transport", "page_size": 1},
+            )
+        finally:
+            reset_matomo_tool_event_action(action_token)
         # search_datasets always returns a TextContent block
         if not content or not isinstance(content[0], TextContent):  # type: ignore
             logger.error("health probe: unexpected response from search_datasets")

--- a/helpers/logging.py
+++ b/helpers/logging.py
@@ -41,9 +41,9 @@ logger = logging.getLogger(TOOLS_LOGGER_NAME)
 def log_tool(func):
     @functools.wraps(func)
     async def async_wrapper(*args, **kwargs):
-        from helpers.matomo import track_matomo_tool
+        from helpers.matomo import matomo_tool_event_for, track_matomo_tool
 
-        asyncio.create_task(track_matomo_tool(func.__name__))
+        asyncio.create_task(track_matomo_tool(matomo_tool_event_for(func.__name__)))
         logger.info("Tool called: %s | kwargs=%s", func.__name__, kwargs)
         return await func(*args, **kwargs)
 

--- a/helpers/matomo.py
+++ b/helpers/matomo.py
@@ -21,6 +21,10 @@ _request_user_agent: ContextVar[str] = ContextVar(
 )
 _request_cip: ContextVar[str] = ContextVar("matomo_request_cip", default="")
 
+_matomo_tool_event_action: ContextVar[str | None] = ContextVar(
+    "matomo_tool_event_action", default=None
+)
+
 # Shared client reused across all tracking calls to avoid creating a new
 # TCP connection + SSL handshake + HTTP client overhead on every MCP request.
 _client = niquests.AsyncSession(timeout=1.5)
@@ -48,6 +52,20 @@ def reset_matomo_request_context(
     _request_page_url.reset(url_token)
     _request_user_agent.reset(ua_token)
     _request_cip.reset(cip_token)
+
+
+def apply_matomo_tool_event_action(action: str) -> Token[str | None]:
+    """Override Matomo e_a for tool call(s) in this async context."""
+    return _matomo_tool_event_action.set(action)
+
+
+def reset_matomo_tool_event_action(token: Token[str | None]) -> None:
+    _matomo_tool_event_action.reset(token)
+
+
+def matomo_tool_event_for(tool_name: str) -> str:
+    """Return Matomo event action for a tool call (override or tool name)."""
+    return _matomo_tool_event_action.get() or tool_name
 
 
 async def _post_matomo(payload: dict) -> None:

--- a/main.py
+++ b/main.py
@@ -73,7 +73,7 @@ def with_monitoring(
                 except PackageNotFoundError:
                     app_version = "unknown"
 
-                is_healthy = await _run_health_check()
+                is_healthy = await _run_health_check(mcp)
                 if is_healthy:
                     body = json.dumps(
                         {

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,8 +1,8 @@
 """
-Health check: full MCP handshake + search_datasets tool call.
+Health check: in-process search_datasets tool call.
 
-Requires a running MCP server (not started by the test).
-Excluded from normal pytest runs -- launch explicitly with:
+Calls the tool layer directly (no HTTP round-trip to localhost/mcp).
+Requires network access to data.gouv.fr. Excluded from normal pytest runs:
 
     uv run pytest -m health_check
 """
@@ -10,16 +10,15 @@ Excluded from normal pytest runs -- launch explicitly with:
 import pytest
 
 from helpers.health_probe import _run_health_check
+from main import mcp
 
 pytestmark = pytest.mark.health_check
 
 
 async def test_health_check():
     """
-    Runs the full MCP handshake and calls search_datasets with page_size=1.
+    Calls search_datasets with page_size=1 in-process.
     Asserts a valid non-empty response to confirm end-to-end stack is healthy.
     """
-    is_healthy = await _run_health_check()
-    assert is_healthy, (
-        "Health check failed: MCP handshake or tool call returned unexpected result"
-    )
+    is_healthy = await _run_health_check(mcp)
+    assert is_healthy, "Health check failed: tool call returned unexpected result"

--- a/tests/test_matomo.py
+++ b/tests/test_matomo.py
@@ -82,22 +82,3 @@ def test_matomo_tool_event_for_uses_override():
         assert matomo.matomo_tool_event_for("search_datasets") == "health_check"
     finally:
         matomo.reset_matomo_tool_event_action(token)
-
-
-@pytest.mark.asyncio
-async def test_track_matomo_tool_with_health_check_action(
-    matomo_post_route, monkeypatch
-):
-    monkeypatch.setattr(matomo, "MATOMO_URL", "https://matomo.example")
-    monkeypatch.setattr(matomo, "MATOMO_SITE_ID", "7")
-    monkeypatch.setattr(matomo, "MATOMO_AUTH_TOKEN", None)
-
-    action_token = matomo.apply_matomo_tool_event_action("health_check")
-    try:
-        await matomo.track_matomo_tool(matomo.matomo_tool_event_for("search_datasets"))
-    finally:
-        matomo.reset_matomo_tool_event_action(action_token)
-
-    body = matomo_post_route.calls[0].request.body
-    params = parse_qs(body, strict_parsing=True)
-    assert params["e_a"] == ["health_check"]

--- a/tests/test_matomo.py
+++ b/tests/test_matomo.py
@@ -74,3 +74,30 @@ async def test_post_matomo_skips_when_not_configured(matomo_post_route, monkeypa
     monkeypatch.setattr(matomo, "MATOMO_SITE_ID", "1")
     await matomo.track_matomo_tool("search_datasets")
     assert not matomo_post_route.called
+
+
+def test_matomo_tool_event_for_uses_override():
+    token = matomo.apply_matomo_tool_event_action("health_check")
+    try:
+        assert matomo.matomo_tool_event_for("search_datasets") == "health_check"
+    finally:
+        matomo.reset_matomo_tool_event_action(token)
+
+
+@pytest.mark.asyncio
+async def test_track_matomo_tool_with_health_check_action(
+    matomo_post_route, monkeypatch
+):
+    monkeypatch.setattr(matomo, "MATOMO_URL", "https://matomo.example")
+    monkeypatch.setattr(matomo, "MATOMO_SITE_ID", "7")
+    monkeypatch.setattr(matomo, "MATOMO_AUTH_TOKEN", None)
+
+    action_token = matomo.apply_matomo_tool_event_action("health_check")
+    try:
+        await matomo.track_matomo_tool(matomo.matomo_tool_event_for("search_datasets"))
+    finally:
+        matomo.reset_matomo_tool_event_action(action_token)
+
+    body = matomo_post_route.calls[0].request.body
+    params = parse_qs(body, strict_parsing=True)
+    assert params["e_a"] == ["health_check"]


### PR DESCRIPTION
Depuis https://github.com/datagouv/datagouv-mcp/commit/9105bac07f3f6b6a7bf0afb8512dfc63b8ce9c8b, le endpoint `/health` s’appelait lui-même en HTTP (POST localhost/mcp) à chaque sonde Docker dans le docker-compose [ici](https://github.com/datagouv/datagouv-mcp/blob/47a1a3048799470dcf7acf99fd5c00bf2f0f1c30/docker-compose.yml#L18). Sur la durée, les sockets ne se libèrent probablement pas correctement et le process finit probablement par atteindre la limite de fichiers ouverts, d'où l'erreur `Too many open files` dans Sentry.

Changements :
- Le health check exécute désormais `search_datasets` en interne, dans le même processus Python, et non en refaisant une requête HTTP. On garde la validation end-to-end (tools + API data.gouv.fr + 503 si échec).
- Nom spécifique pour l'event health check quand il appelle search_dataset pour le différencier des autres (à terme on pourra même ne pas appeler Matomo mais dans un premier temps c'est bien de les compter)


### AI-generated content

**Raw AI-only pull requests (code you have not personally edited, fully understood, and tested) are not allowed and may be closed without discussion.** By submitting, you state you understand this change and can defend it without an AI.

All other rules (workflow, commits, review): **[Contributing guidelines](https://github.com/datagouv/datagouv-mcp/blob/main/README.md#contributing)**.

#### Checklist

- [x] I am not submitting raw, unreviewed AI-generated content. I have reviewed, understand, and stand behind this PR.
