### PR TITLE
fix: matomo healthcheck stats

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python", "-c", "import os, urllib.request; port = os.getenv('MCP_PORT', '8000'); urllib.request.urlopen(f'http://localhost:{port}/health')"]
-      interval: 30s
+      interval: 60s
       timeout: 10s
       retries: 3
       start_period: 10s

--- a/helpers/health_probe.py
+++ b/helpers/health_probe.py
@@ -14,8 +14,8 @@ from mcp.types import TextContent
 
 from helpers.logging import MAIN_LOGGER_NAME
 from helpers.matomo import (
-    apply_matomo_tool_event_override,
-    reset_matomo_tool_event_override,
+    apply_matomo_event_override,
+    reset_matomo_event_override,
 )
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
@@ -24,7 +24,7 @@ logger = logging.getLogger(MAIN_LOGGER_NAME)
 async def _run_health_check(mcp: FastMCP) -> bool:
     logger.debug("health probe: starting health check")
     try:
-        override = apply_matomo_tool_event_override(
+        override_token = apply_matomo_event_override(
             action="health_check",
             category="health_check",
         )
@@ -34,7 +34,7 @@ async def _run_health_check(mcp: FastMCP) -> bool:
                 {"query": "transport", "page_size": 1},
             )
         finally:
-            reset_matomo_tool_event_override(*override)
+            reset_matomo_event_override(override_token)
         # search_datasets always returns a TextContent block
         if not content or not isinstance(content[0], TextContent):  # type: ignore
             logger.error("health probe: unexpected response from search_datasets")

--- a/helpers/health_probe.py
+++ b/helpers/health_probe.py
@@ -14,8 +14,8 @@ from mcp.types import TextContent
 
 from helpers.logging import MAIN_LOGGER_NAME
 from helpers.matomo import (
-    apply_matomo_tool_event_action,
-    reset_matomo_tool_event_action,
+    apply_matomo_tool_event_override,
+    reset_matomo_tool_event_override,
 )
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
@@ -24,14 +24,17 @@ logger = logging.getLogger(MAIN_LOGGER_NAME)
 async def _run_health_check(mcp: FastMCP) -> bool:
     logger.debug("health probe: starting health check")
     try:
-        action_token = apply_matomo_tool_event_action("health_check")
+        override = apply_matomo_tool_event_override(
+            action="health_check",
+            category="health_check",
+        )
         try:
             content, _ = await mcp.call_tool(
                 "search_datasets",
                 {"query": "transport", "page_size": 1},
             )
         finally:
-            reset_matomo_tool_event_action(action_token)
+            reset_matomo_tool_event_override(*override)
         # search_datasets always returns a TextContent block
         if not content or not isinstance(content[0], TextContent):  # type: ignore
             logger.error("health probe: unexpected response from search_datasets")

--- a/helpers/logging.py
+++ b/helpers/logging.py
@@ -41,9 +41,9 @@ logger = logging.getLogger(TOOLS_LOGGER_NAME)
 def log_tool(func):
     @functools.wraps(func)
     async def async_wrapper(*args, **kwargs):
-        from helpers.matomo import matomo_tool_event_for, track_matomo_tool
+        from helpers.matomo import track_matomo_event
 
-        asyncio.create_task(track_matomo_tool(matomo_tool_event_for(func.__name__)))
+        asyncio.create_task(track_matomo_event(func.__name__))
         logger.info("Tool called: %s | kwargs=%s", func.__name__, kwargs)
         return await func(*args, **kwargs)
 

--- a/helpers/matomo.py
+++ b/helpers/matomo.py
@@ -11,7 +11,7 @@ from helpers.logging import MAIN_LOGGER_NAME
 MATOMO_URL = os.getenv("MATOMO_URL")
 MATOMO_SITE_ID = os.getenv("MATOMO_SITE_ID")
 MATOMO_AUTH_TOKEN = os.getenv("MATOMO_AUTH_TOKEN")
-MATOMO_TOOL_EVENT_CATEGORY = "MCP"
+MATOMO_TOOL_EVENT_CATEGORY = "tools"
 
 _request_page_url: ContextVar[str] = ContextVar(
     "matomo_request_page_url", default="https://localhost/mcp"
@@ -23,6 +23,9 @@ _request_cip: ContextVar[str] = ContextVar("matomo_request_cip", default="")
 
 _matomo_tool_event_action: ContextVar[str | None] = ContextVar(
     "matomo_tool_event_action", default=None
+)
+_matomo_tool_event_category: ContextVar[str | None] = ContextVar(
+    "matomo_tool_event_category", default=None
 )
 
 # Shared client reused across all tracking calls to avoid creating a new
@@ -54,18 +57,36 @@ def reset_matomo_request_context(
     _request_cip.reset(cip_token)
 
 
-def apply_matomo_tool_event_action(action: str) -> Token[str | None]:
-    """Override Matomo e_a for tool call(s) in this async context."""
-    return _matomo_tool_event_action.set(action)
+def apply_matomo_tool_event_override(
+    *,
+    action: str | None = None,
+    category: str | None = None,
+) -> tuple[Token[str | None] | None, Token[str | None] | None]:
+    """Override Matomo e_a and/or e_c for tool call(s) in this async context."""
+    return (
+        _matomo_tool_event_action.set(action) if action is not None else None,
+        _matomo_tool_event_category.set(category) if category is not None else None,
+    )
 
 
-def reset_matomo_tool_event_action(token: Token[str | None]) -> None:
-    _matomo_tool_event_action.reset(token)
+def reset_matomo_tool_event_override(
+    action_token: Token[str | None] | None,
+    category_token: Token[str | None] | None,
+) -> None:
+    if action_token is not None:
+        _matomo_tool_event_action.reset(action_token)
+    if category_token is not None:
+        _matomo_tool_event_category.reset(category_token)
 
 
 def matomo_tool_event_for(tool_name: str) -> str:
     """Return Matomo event action for a tool call (override or tool name)."""
     return _matomo_tool_event_action.get() or tool_name
+
+
+def matomo_tool_event_category_for() -> str:
+    """Return Matomo event category for a tool call (override or default)."""
+    return _matomo_tool_event_category.get() or MATOMO_TOOL_EVENT_CATEGORY
 
 
 async def _post_matomo(payload: dict) -> None:
@@ -91,7 +112,7 @@ async def track_matomo_tool(tool_name: str) -> None:
         "rec": 1,
         "url": _request_page_url.get(),
         "ca": 1,
-        "e_c": MATOMO_TOOL_EVENT_CATEGORY,
+        "e_c": matomo_tool_event_category_for(),
         "e_a": tool_name,
         "ua": _request_user_agent.get(),
         "rand": str(random.randint(10**15, 10**16 - 1)),

--- a/helpers/matomo.py
+++ b/helpers/matomo.py
@@ -11,7 +11,7 @@ from helpers.logging import MAIN_LOGGER_NAME
 MATOMO_URL = os.getenv("MATOMO_URL")
 MATOMO_SITE_ID = os.getenv("MATOMO_SITE_ID")
 MATOMO_AUTH_TOKEN = os.getenv("MATOMO_AUTH_TOKEN")
-MATOMO_TOOL_EVENT_CATEGORY = "tools"
+MATOMO_DEFAULT_EVENT_CATEGORY = "tools"
 
 _request_page_url: ContextVar[str] = ContextVar(
     "matomo_request_page_url", default="https://localhost/mcp"
@@ -21,11 +21,8 @@ _request_user_agent: ContextVar[str] = ContextVar(
 )
 _request_cip: ContextVar[str] = ContextVar("matomo_request_cip", default="")
 
-_matomo_tool_event_action: ContextVar[str | None] = ContextVar(
-    "matomo_tool_event_action", default=None
-)
-_matomo_tool_event_category: ContextVar[str | None] = ContextVar(
-    "matomo_tool_event_category", default=None
+_matomo_event_override: ContextVar[tuple[str | None, str | None]] = ContextVar(
+    "matomo_event_override", default=(None, None)
 )
 
 # Shared client reused across all tracking calls to avoid creating a new
@@ -57,36 +54,24 @@ def reset_matomo_request_context(
     _request_cip.reset(cip_token)
 
 
-def apply_matomo_tool_event_override(
-    *,
+def apply_matomo_event_override(
     action: str | None = None,
     category: str | None = None,
-) -> tuple[Token[str | None] | None, Token[str | None] | None]:
+) -> Token[tuple[str | None, str | None]]:
     """Override Matomo e_a and/or e_c for tool call(s) in this async context."""
-    return (
-        _matomo_tool_event_action.set(action) if action is not None else None,
-        _matomo_tool_event_category.set(category) if category is not None else None,
+    current_action, current_category = _matomo_event_override.get()
+    return _matomo_event_override.set(
+        (
+            action if action is not None else current_action,
+            category if category is not None else current_category,
+        )
     )
 
 
-def reset_matomo_tool_event_override(
-    action_token: Token[str | None] | None,
-    category_token: Token[str | None] | None,
+def reset_matomo_event_override(
+    token: Token[tuple[str | None, str | None]],
 ) -> None:
-    if action_token is not None:
-        _matomo_tool_event_action.reset(action_token)
-    if category_token is not None:
-        _matomo_tool_event_category.reset(category_token)
-
-
-def matomo_tool_event_for(tool_name: str) -> str:
-    """Return Matomo event action for a tool call (override or tool name)."""
-    return _matomo_tool_event_action.get() or tool_name
-
-
-def matomo_tool_event_category_for() -> str:
-    """Return Matomo event category for a tool call (override or default)."""
-    return _matomo_tool_event_category.get() or MATOMO_TOOL_EVENT_CATEGORY
+    _matomo_event_override.reset(token)
 
 
 async def _post_matomo(payload: dict) -> None:
@@ -102,18 +87,23 @@ async def _post_matomo(payload: dict) -> None:
         )
 
 
-async def track_matomo_tool(tool_name: str) -> None:
+async def track_matomo_event(
+    name: str,
+    action: str | None = None,
+    category: str | None = None,
+) -> None:
     """
-    Track an MCP tool invocation as a Matomo event (Behavior > Events).
+    Track a Matomo event (Behavior > Events).
     Uses e_c / e_a and ca=1 per the HTTP Tracking API.
     """
+    action_override, category_override = _matomo_event_override.get()
     payload = {
         "idsite": MATOMO_SITE_ID,
         "rec": 1,
         "url": _request_page_url.get(),
         "ca": 1,
-        "e_c": matomo_tool_event_category_for(),
-        "e_a": tool_name,
+        "e_c": category or category_override or MATOMO_DEFAULT_EVENT_CATEGORY,
+        "e_a": action or action_override or name,
         "ua": _request_user_agent.get(),
         "rand": str(random.randint(10**15, 10**16 - 1)),
     }

--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ def with_monitoring(
         if scope["type"] == "http":
             path: str = scope.get("path", "")
 
-            # Handle /health endpoint (no tracking)
+            # Handle /health endpoint (no HTTP request context binding for Matomo)
             if path == "/health":
                 # Get version from package metadata (managed by setuptools-scm)
                 try:

--- a/tests/test_matomo.py
+++ b/tests/test_matomo.py
@@ -34,7 +34,7 @@ async def test_track_matomo_tool_sends_event_fields(matomo_post_route, monkeypat
     body = matomo_post_route.calls[0].request.body
     params = parse_qs(body, strict_parsing=True)
     assert params["idsite"] == ["7"]
-    assert params["e_c"] == ["MCP"]
+    assert params["e_c"] == ["tools"]
     assert params["e_a"] == ["search_datasets"]
     assert params["ca"] == ["1"]
     assert params["url"] == ["https://mcp.example/mcp"]
@@ -76,9 +76,13 @@ async def test_post_matomo_skips_when_not_configured(matomo_post_route, monkeypa
     assert not matomo_post_route.called
 
 
-def test_matomo_tool_event_for_uses_override():
-    token = matomo.apply_matomo_tool_event_action("health_check")
+def test_matomo_tool_event_override():
+    override = matomo.apply_matomo_tool_event_override(
+        action="health_check",
+        category="health_check",
+    )
     try:
         assert matomo.matomo_tool_event_for("search_datasets") == "health_check"
+        assert matomo.matomo_tool_event_category_for() == "health_check"
     finally:
-        matomo.reset_matomo_tool_event_action(token)
+        matomo.reset_matomo_tool_event_override(*override)

--- a/tests/test_matomo.py
+++ b/tests/test_matomo.py
@@ -17,7 +17,7 @@ def matomo_post_route(niquests_mock: MockRouter) -> MockRoute:
 
 
 @pytest.mark.asyncio
-async def test_track_matomo_tool_sends_event_fields(matomo_post_route, monkeypatch):
+async def test_track_matomo_event_sends_event_fields(matomo_post_route, monkeypatch):
     monkeypatch.setattr(matomo, "MATOMO_URL", "https://matomo.example")
     monkeypatch.setattr(matomo, "MATOMO_SITE_ID", "7")
     monkeypatch.setattr(matomo, "MATOMO_AUTH_TOKEN", None)  # omitted from POST body
@@ -26,7 +26,7 @@ async def test_track_matomo_tool_sends_event_fields(matomo_post_route, monkeypat
         "/mcp",
     )
     try:
-        await matomo.track_matomo_tool("search_datasets")
+        await matomo.track_matomo_event("search_datasets")
     finally:
         matomo.reset_matomo_request_context(url_tok, ua_tok, cip_tok)
 
@@ -43,7 +43,7 @@ async def test_track_matomo_tool_sends_event_fields(matomo_post_route, monkeypat
 
 
 @pytest.mark.asyncio
-async def test_track_matomo_tool_forwards_cip_from_context(
+async def test_track_matomo_event_forwards_cip_from_context(
     matomo_post_route, monkeypatch
 ):
     monkeypatch.setattr(matomo, "MATOMO_URL", "https://matomo.example")
@@ -58,7 +58,7 @@ async def test_track_matomo_tool_forwards_cip_from_context(
         "/mcp",
     )
     try:
-        await matomo.track_matomo_tool("search_datasets")
+        await matomo.track_matomo_event("search_datasets")
     finally:
         matomo.reset_matomo_request_context(url_tok, ua_tok, cip_tok)
 
@@ -72,17 +72,37 @@ async def test_track_matomo_tool_forwards_cip_from_context(
 async def test_post_matomo_skips_when_not_configured(matomo_post_route, monkeypatch):
     monkeypatch.setattr(matomo, "MATOMO_URL", "")
     monkeypatch.setattr(matomo, "MATOMO_SITE_ID", "1")
-    await matomo.track_matomo_tool("search_datasets")
+    await matomo.track_matomo_event("search_datasets")
     assert not matomo_post_route.called
 
 
-def test_matomo_tool_event_override():
-    override = matomo.apply_matomo_tool_event_override(
+@pytest.mark.asyncio
+async def test_track_matomo_event_action_and_category_override(
+    matomo_post_route, monkeypatch
+):
+    monkeypatch.setattr(matomo, "MATOMO_URL", "https://matomo.example")
+    monkeypatch.setattr(matomo, "MATOMO_SITE_ID", "7")
+
+    await matomo.track_matomo_event(
+        "search_datasets",
+        action="health_check",
+        category="health_check",
+    )
+    explicit_body = matomo_post_route.calls[0].request.body
+    explicit_params = parse_qs(explicit_body, strict_parsing=True)
+    assert explicit_params["e_c"] == ["health_check"]
+    assert explicit_params["e_a"] == ["health_check"]
+
+    override_token = matomo.apply_matomo_event_override(
         action="health_check",
         category="health_check",
     )
     try:
-        assert matomo.matomo_tool_event_for("search_datasets") == "health_check"
-        assert matomo.matomo_tool_event_category_for() == "health_check"
+        await matomo.track_matomo_event("search_datasets")
     finally:
-        matomo.reset_matomo_tool_event_override(*override)
+        matomo.reset_matomo_event_override(override_token)
+
+    context_body = matomo_post_route.calls[1].request.body
+    context_params = parse_qs(context_body, strict_parsing=True)
+    assert context_params["e_c"] == ["health_check"]
+    assert context_params["e_a"] == ["health_check"]


### PR DESCRIPTION
Matomo tracks every MCP tool call as an event. The `/health` endpoint also runs a real tool call internally to verify the stack, and those automatic probes were counted alongside genuine user usage, which made usage stats harder to read.

Changes:
- real MCP tool calls are tracked under the _tools_ category, while health probe events calls go under _health_check_ category.
- Docker Compose health check interval is also increased from 30s to 60s, since probes were firing quite often.
- Simplify Matomo event overriding.
